### PR TITLE
Inline links need trailing slash to work

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -64,7 +64,7 @@ export default () => (
                 As mentioned, attendees will get to vote on the talks they wish to see. Talks will be selected by popular vote, but with some discretion by the organisors of the conference. The discretion is to ensure variety at the conference. If two or more talks are nearly exactly the same, the most popular will continue through and the next most popular, different talk will replace the one with identical content. 
             </p>
             <p>
-                We also ask that all talk submissions abide to the <a href="/code-of-conduct">Code of Conduct</a>. We want all attendees to feel comfortable at the event, so ask that no submissions or talks contain content of a graphic, voilent or sexual nature or contain any language that may be considered marginalising or hateful. If you wouldn't want to say it to someone you respect, please don't include it in your submission. Organisers hold the right to remove anything that may be thought to cause distress.
+                We also ask that all talk submissions abide to the <a href="/code-of-conduct/">Code of Conduct</a>. We want all attendees to feel comfortable at the event, so ask that no submissions or talks contain content of a graphic, voilent or sexual nature or contain any language that may be considered marginalising or hateful. If you wouldn't want to say it to someone you respect, please don't include it in your submission. Organisers hold the right to remove anything that may be thought to cause distress.
             </p>
         </section>
         <section>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -92,7 +92,7 @@ export default () => (
             <a name="dddmeaning"/>
             <h2>Q: What does DDD stand for?</h2>
             <p>
-                <strong>A: </strong> Developer! Developer! Developer! See more details on our <a href="/about">About page</a>. 
+                <strong>A: </strong> Developer! Developer! Developer! See more details on our <a href="/about/">About page</a>. 
             </p>
         </section>
 
@@ -147,7 +147,7 @@ export default () => (
             <a name="coordinators"/>
             <h2>Q: Who is coordinating the event?</h2>
             <p>
-                <strong>A: </strong> Jessica White and Moreton Brockley. For more information see the bottom of the <a href="/about">About page</a>. 
+                <strong>A: </strong> Jessica White and Moreton Brockley. For more information see the bottom of the <a href="/about/">About page</a>. 
             </p>
         </section>
 


### PR DESCRIPTION
### Requirements

Any inline action links need to have a trailing slash for local addresses to work otherwise it redirects to home.

### Benefits

Less confusing user experience

