### PR TITLE
fix cache invalidation path

### DIFF
--- a/aws_deploy
+++ b/aws_deploy
@@ -12,5 +12,5 @@ echo "AWS CLI configured"
 aws s3 sync ./out s3://www.dddeastmidlands.com --delete
 echo "Deployed to S3"
 
-aws cloudfront create-invalidation --distribution-id E337487SP9DI6L --paths /*
-echo "Cloufront distribution invalidated"
+aws cloudfront create-invalidation --distribution-id E337487SP9DI6L --paths "/*"
+echo "Cloudfront distribution invalidated"


### PR DESCRIPTION
### Description of the Change

Fixes cloudfront invalidation path to not be some random server directories.

### Benefits

Expected paths are actually invalidated in the cloudfront cache.