### PR TITLE
Add tabbing behavior

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -5,7 +5,7 @@ const Header = (props) => (
         <div className="background"></div>
         <div className="logo">
             <img className="image" src="/static/ddd_avatar_300.jpg" alt="DDD East Midlands Logo"/>
-            <h1>{props.title}</h1>
+            <h1 tabIndex="0">{props.title}</h1>
         </div>
         <style jsx>
             {`

--- a/components/home/ImportantDate.js
+++ b/components/home/ImportantDate.js
@@ -3,11 +3,11 @@ import theme from '../../theme/theme'
 const ImportantDate = (props) => (
 
     <div className="boxItem">
-        <div className="top">
+        <div  tabIndex="0" className="top">
             {props.dates.name}
         </div>
         <div className="bottomBackground">
-        <div className="bottom">
+        <div  tabIndex="0" className="bottom">
             {props.dates.date}
         </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2869,13 +2869,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2888,18 +2886,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3002,8 +2997,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3013,7 +3007,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3026,20 +3019,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3056,7 +3046,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3129,8 +3118,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3140,7 +3128,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3246,7 +3233,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/pages/about/about.js
+++ b/pages/about/about.js
@@ -11,7 +11,7 @@ export default () => (
         </Head>
         <Header title={'About DDDEM'}/>
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
 
             <p><strong><a href="#about">About DDD East Midlands</a></strong></p>
             <ul>
@@ -42,8 +42,8 @@ export default () => (
 
         <section id="about">
             <a name="about"/>
-            <h1>About DDD East Midlands</h1>
-            <p>
+            <h1 tabIndex="0">About DDD East Midlands</h1>
+            <p tabIndex="0">
                 Nottingham is the perfect blend of the professional corporates and the innovative independents and this
                 bleeds right through to the tech scene. This unique and perfect mix of the traditional and contemporary
                 is reflected in DDD East Midlands. It is part of the multi-national DDD conference community, but with a
@@ -51,14 +51,14 @@ export default () => (
             </p>
 
             <a name="ddd"/>
-            <h2>But what is the DDD about? What is this conference?</h2>
-            <p>
+            <h2 tabIndex="0">But what is the DDD about? What is this conference?</h2>
+            <p tabIndex="0">
                 DDD stands for (in this case) <b>Developer! Developer! Developer!</b>
             </p>
-            <p>
+            <p tabIndex="0">
                It's often asked if we are a conference centred around Domain Driven Design or some other acronym that fits, that is not the case. We are a general technology conference. This means that we will accept talk submissions relating to technology no matter the language, the discipline or otherwise. Unfortunately us technologists (particularly the ones that program) love acroymns containing the letter D.
             </p>
-            <p>
+            <p tabIndex="0">
                Developer! Developer! Developer! is an umbrella, open-source conference format. By naming ourselves DDD, and associating ourselves with similar events, we abide by certain principles. Other than that, this conference is by the East Midlands community for the East Midlands community and is unique in its own right. There is more information about Developer! Developer! Developer! further down this page for those interested.
             </p>
         </section> 
@@ -71,17 +71,17 @@ export default () => (
 
         <section>
             <a name="principles"/>
-            <h2>The event follows these DDD Principles:</h2>
+            <h2 tabIndex="0">The event follows these DDD Principles:</h2>
 
             <ul>
-                <li>The event is hosted on a Saturday so that attendees do not have to take time from work.</li>
-                <li> Tickets to attend the event are free.</li>
-                <li>All talk submissions are anonymous.</li>
-                <li>There is a democratic selection process for talks involving attendees voting for what they want
+                <li tabIndex="0">The event is hosted on a Saturday so that attendees do not have to take time from work.</li>
+                <li tabIndex="0"> Tickets to attend the event are free.</li>
+                <li tabIndex="0">All talk submissions are anonymous.</li>
+                <li tabIndex="0">There is a democratic selection process for talks involving attendees voting for what they want
                     to
                     see.
                 </li>
-                <li>The event is arranged with the community in mind.
+                <li tabIndex="0">The event is arranged with the community in mind.
                 </li>
             </ul>
         </section>
@@ -92,52 +92,52 @@ export default () => (
 
         <section id="inclusivity">
             <a name="inclusivity"/>
-            <h1>Promoting Inclusivity</h1>
-            <p>
+            <h1 tabIndex="0">Promoting Inclusivity</h1>
+            <p tabIndex="0">
                 As an embodiment of the East Midlands tech community, we want to promote inclusivity, support and
                 camaraderie. Here are just a few of the ways we ai to do this:
             </p>
 
             <a name="accessibility"/>            
-            <h2>Accessibilty Page</h2>
-            <p>
+            <h2 tabIndex="0">Accessibilty Page</h2>
+            <p tabIndex="0">
                 In order to remain transparent, we have tried to answer as many accessibilty related questions as we could on our <a href="/about/accessibility-information" target="_blank">Accessibility Page</a>.
             </p>
 
             <a name="selection"/>            
-            <h2>Submission And Selection Process</h2>
-            <p>
+            <h2 tabIndex="0">Submission And Selection Process</h2>
+            <p tabIndex="0">
                 In line with the DDD principles, the submission process is anonymous and the selection process democratic. This is a conference for the community, by the community. All talks that are submitted are anonymous. When the attendees vote on which talks they want to see, and when the organisers are sorting out the agenda, identifiable information about those who have submitted can't bee seen. This is to keep the process as fair as possible and ensure talks are picked on their advertised content, not by who is presenting.
             </p>
-            <p>
+            <p tabIndex="0">
                 As mentioned, attendees will get to vote on the talks they wish to see. Talks will be selected by popular vote, but with some discretion by the organisers of the conference. The discretion is to ensure variety at the conference. If two or more talks are nearly exactly the same, the most popular will continue through and the next most popular, different talk will replace the one with identical content. 
             </p>
-            <p>
+            <p tabIndex="0">
                 We also ask that all talk submissions abide to the <a href="/code-of-conduct/">Code of Conduct</a>. We want all attendees to feel comfortable at the event, so ask that no submissions or talks contain content of a graphic, violent or sexual nature or contain any language that may be considered marginalising or hateful. If you wouldn't want to say it to someone you respect, please don't include it in your submission. Organisers hold the right to remove anything that may be thought to cause distress.
             </p>
 
             <a name="speaking"/>            
-            <h2>Making speaking accessible</h2>
-            <p>
+            <h2 tabIndex="0">Making speaking accessible</h2>
+            <p tabIndex="0">
                 We would like to encourage more people to speak and to encourage a diverse range of backgrounds, experiences and tech related roles to come and share their learnings at our event. There are a number of ways in which we are trying to make speaking more accessible:
             </p>
             <ul>
-                <li><b>Offering mentors for speakers that are selected and request extra help.</b></li>
-                <p>
+                <li tabIndex="0"><b>Offering mentors for speakers that are selected and request extra help.</b></li>
+                <p tabIndex="0">
                     Speaking in front of a crowd of people isn't easy and we know it. There will be the option to highlight that you would like extra support, as a first-time speaker, or even just as someone who feels that they would benefit from it.
                 </p>
-                <p>
+                <p tabIndex="0">
                     The East Midlands is lucky to host some amazing (and incredibly generous) international and experienced speakers. Some of these fine people are donating their time to any speakers that indicate they want extra support. This support covers ways to address nerves, timing a talk, structuring the content of a talk, making sure your talk aligns to its description and more.
                 </p>
-                <li><b>Arranging an optional workshop for all speakers to help them construct their talk.</b></li>
-                <p>
+                <li tabIndex="0"><b>Arranging an optional workshop for all speakers to help them construct their talk.</b></li>
+                <p tabIndex="0">
                     All selected speakers will be invited to an optional workshop before the event. This contains advise on subjects such as talk structure, presentation styles, designing your slides. This is made possible by our very kind Workshop Sponsor. More details will be described here closer to the event.
                 </p>
-                <li><b>Organisers are speaking at meetups about how to submit a good abstract.</b></li>
-                <p>
+                <li tabIndex="0"><b>Organisers are speaking at meetups about how to submit a good abstract.</b></li>
+                <p tabIndex="0">
                    All the above is great if you get selected as a speaker, but how can we help you get there? The organisers of DDD East Midlands, <a href="https://twitter.com/allmobro" target="_blank">Moreton Brockley</a> and <a href="https://twitter.com/JessPWhite" target="_blank">Jessica White</a> are going to present a talk on how to submit a talk to the conference, but also give tips on how to create a talk description/abstract that stands out.
                 </p>
-                <p>
+                <p tabIndex="0">
                    If you run an event in the East Midlands and would like us to come across to present this talk, get in touch. We will also make efforts to write the content of this talk in a blog to increase the ease of access to the content.
                 </p>
             </ul>
@@ -149,24 +149,24 @@ export default () => (
 
         <section id="ddd-about">
             <a name="ddd-about"/>            
-            <h1>About Developer! Developer! Developer! (DDD)</h1>
-            <p>
+            <h1 tabIndex="0">About Developer! Developer! Developer! (DDD)</h1>
+            <p tabIndex="0">
                 DDD was first formed as a conference in 2005, the first event happening in Reading, UK. Since then it
                 has generated many spin-off events across the world.
             </p>
-            <p>
+            <p tabIndex="0">
                 The aims of the original DDD was to provide free technical education. During it’s more than 10-year
                 history, it has nurtured talented speakers, who have gone on to become Microsoft Most Valuable
                 Professionals, Microsoft FTEs and to present at National and International Conferences.
             </p>
-            <p>
+            <p tabIndex="0">
                 Though the original DDD conference is focused on .NET, DDD East Midlands is going to be open to a range
                 of talks within the field of technology. It is language and technology agnostic.
             </p>
 
             <a name="ddd-about"/>            
-            <h2>Other DDD Events</h2>
-            <p><b>UK</b></p>
+            <h2 tabIndex="0">Other DDD Events</h2>
+            <p tabIndex="0"><b>UK</b></p>
             <ul>
                <li><a href="https://twitter.com/Reading" target="_blank">DDD Reading</a></li>
                <li><a href="https://twitter.com/dddnorth" target="_blank">DDD North</a></li>
@@ -176,14 +176,14 @@ export default () => (
                 <li><a href="https://twitter.com/dddbelfast" target="_blank">DDD Belfast</a></li>
                 <li><a href="https://www.dddwales.com/" target="_blank">DDD Wales</a></li>
             </ul>
-            <p><b>Australia</b></p>
+            <p tabIndex="0"><b>Australia</b></p>
             <ul>
                 <li><a href="https://www.dddmelbourne.com/" target="_blank">DDD Melbourne</a></li>
                 <li><a href="http://next.dddsydney.com.au/" target="_blank">DDD Sydney</a></li>
                 <li><a href="https://www.dddbrisbane.com/" target="_blank">DDD Brisbane</a></li>
                 <li><a href="https://www.dddperth.com/" target="_blank">DDD Perth</a></li>
             </ul>
-            <p><b>Netherlands</b></p>
+            <p tabIndex="0"><b>Netherlands</b></p>
             <ul>
             <li><a href="https://twitter.com/DDDNetherlands" target="_blank">DDD Netherlands</a></li>
             </ul>
@@ -191,8 +191,8 @@ export default () => (
 
         <section id="organisers">
             <a name="organisers"/>            
-            <h1>The Organisers</h1>
-            <p>
+            <h1 tabIndex="0">The Organisers</h1>
+            <p tabIndex="0">
                 The very first DDD East Midlands is being organised by Moreton Brockley and Jessica White. Both have
                 been active members of the East Midlands tech scene for a number of years and have benefited through
                 making lifelong friends, experiencing awesome events and learning. They are eager to celebrate the East
@@ -206,8 +206,8 @@ export default () => (
         </section>           
         <section>
             <a name="jessica"/>            
-            <h2>Jessica White</h2>
-            <p>
+            <h2 tabIndex="0">Jessica White</h2>
+            <p tabIndex="0">
                 Fully caffeinated, Jessica is more whirling dervish than person. Having founded <a href="">Women In Tech Nottingham</a>
                 back in 2015, and running it for nearly 2 years, she has previous experience with running an inclusive
                 event. You will be in touch with Jessica if you are considering sponsoring the event or have any awesome
@@ -219,8 +219,8 @@ export default () => (
             </p>
 
             <a name="moreton"/>            
-            <h2>Moreton Brockley</h2>
-            <p>
+            <h2 tabIndex="0">Moreton Brockley</h2>
+            <p tabIndex="0">
                 A Delivery Manager and developer, Moreton is the sensible head of the co-founders. He is the number
                 whizz and the fashion guru. Seriously, check out his Ninja Turtle Doc Martens. You may (not) recognise Moreton from his performance at 2018's Hack24 as Mr Blobby.
             </p>
@@ -230,7 +230,7 @@ export default () => (
             </p>
         </section>
         <section>
-            <p>
+            <p tabIndex="0">
                 Give them a follow on Twitter, say hi at the local events, offer them a coffee or some chocolate if they
                 look in need. They will both be running around on the day of the event making sure your experience of it is the best they can possibly make it.
             </p>

--- a/pages/about/accessibility-information.js
+++ b/pages/about/accessibility-information.js
@@ -11,44 +11,44 @@ export default () => (
         <Header title={'Accessibility Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
-            <p><strong>Multi-faith/Quiet Contemplation Room</strong></p>
+            <h1 tabIndex="0">Contents</h1>
+            <p tabIndex="0"><strong>Multi-faith/Quiet Contemplation Room</strong></p>
             <ul>
                 <li><a href="#prayerroom">Will be a place to pray available?</a></li>
             </ul>
 
-            <p><strong>Childcare</strong></p>
+            <p tabIndex="0"><strong>Childcare</strong></p>
             <ul>
                 <li><a href="#childcare">Will childcare be available?</a></li>
             </ul>
             
-            <p><strong>Gendered Bathrooms</strong></p>
+            <p tabIndex="0"><strong>Gendered Bathrooms</strong></p>
             <ul>
                 <li><a href="#genderbathrooms">Are bathrooms gender neutral?</a></li>
             </ul>
             
-            <p><strong>Wheelchair Access</strong></p>
+            <p tabIndex="0"><strong>Wheelchair Access</strong></p>
             <ul>
                 <li><a href="#wheelchairaccessoutside">What is wheelchair access like outside the venue? I.e. Are kerbs high?</a></li>
                 <li><a href="#wheelchairaccessinside">What is wheelchair access like inside the venue? Is it easy to get in/around the building?</a></li>
                 <li><a href="#wheelchairbathrooms">Are there accessible bathrooms for wheelchair users?</a></li>
             </ul>
             
-            <p><strong>Audio/Visual</strong></p>
+            <p tabIndex="0"><strong>Audio/Visual</strong></p>
             <ul>
                 <li><a href="#largeprint">Do you have large print versions of your materials, flyers, resources etc?</a></li>
                 <li><a href="#audiodescribed">Will you have audio-described resources?</a></li>
                 <li><a href="#captionedtalks">Will talks be captioned?</a></li>
             </ul>
             
-            <p><strong>Dietary/Alchol Concerns</strong></p>
+            <p tabIndex="0"><strong>Dietary/Alchol Concerns</strong></p>
             <ul>
                 <li><a href="#diet-reqs">Will dietary requirements be catered to?</a></li>
                 <li><a href="#ownfood">Are people welcome to bring their own food?</a></li>
                 <li><a href="#alcohol">Are people going to be using alcohol?</a></li>
             </ul>
 
-            <p><strong>Assistance Animals</strong></p>
+            <p tabIndex="0"><strong>Assistance Animals</strong></p>
             <ul>
                 <li><a href="#assistanceanimals">Are assistance animals allowed in the venue?</a></li>
             </ul>
@@ -56,106 +56,106 @@ export default () => (
      
         
         <section id="prayerroom">
-            <h1>Multi-faith/Quiet Contemplation Room</h1>
+            <h1 tabIndex="0">Multi-faith/Quiet Contemplation Room</h1>
 
             <a name="prayerroom"/>
-            <h2>Will be a place to pray available?</h2>
-            <p>
+            <h2 tabIndex="0">Will be a place to pray available?</h2>
+            <p tabIndex="0">
                 There will be a prayer room available on the day. It will be marked on the maps and all volunteers will know where it will be located.
             </p>
         </section>
 
         <section id="childcare">
-            <h1>Childcare</h1>
+            <h1 tabIndex="0">Childcare</h1>
 
             <a name="childcare"/>
-            <h2>Will childcare be available?</h2>
-            <p>
+            <h2 tabIndex="0">Will childcare be available?</h2>
+            <p tabIndex="0">
                 Unfortunately we will not be able to provide childcare at this first event. The overhead and cost were too high on this instance, but we would love to find a way in the future. Accessibility is important to us and we would love to make it easier for parents to attend the conference.
             </p>
         </section>
 
         <section id="genderbathrooms">
-            <h1>Gendered Bathrooms</h1>
+            <h1 tabIndex="0">Gendered Bathrooms</h1>
             <a name="genderbathrooms"/>
-            <h2>Are bathrooms gender neutral?</h2>
-            <p>
+            <h2 tabIndex="0">Are bathrooms gender neutral?</h2>
+            <p tabIndex="0">
                 Unfortunately, this isn't the case at this years event. The NCC is converting some of it's toilets to be gender neutral but this won't be in place until after the event.
             </p>
         </section>
 
         <section id="wheelchairaccess">
-            <h1>Wheelchair Access</h1>
+            <h1 tabIndex="0">Wheelchair Access</h1>
 
             <a name="wheelchairaccessoutside"/>
-            <h2>What is wheelchair access like outside the venue?</h2>
-            <p>
+            <h2 tabIndex="0">What is wheelchair access like outside the venue?</h2>
+            <p tabIndex="0">
                 Both the Goldsmith Street entrance and the Burton street entrance are accessible and there are lifts to all levels. The wheelchair door on Burton Street is a push button entrance door.            
             </p>
 
             <a name="wheelchairaccessinside"/>
-            <h2>What is wheelchair access like inside the venue?</h2>
-            <p>
+            <h2 tabIndex="0">What is wheelchair access like inside the venue?</h2>
+            <p tabIndex="0">
                 Wheelchair access is good. There are no steps/lips on doors to watch out for.
             </p>
 
             <a name="wheelchairbathrooms"/>
-            <h2>Are there accessible bathrooms for wheelchair users?</h2>
-            <p>
+            <h2 tabIndex="0">Are there accessible bathrooms for wheelchair users?</h2>
+            <p tabIndex="0">
                 There are on each level.
             </p>
         </section>
 
         <section id="audio-visual">
-            <h1>Audio/Visual</h1>
+            <h1 tabIndex="0">Audio/Visual</h1>
 
             <a name="largeprint"/>
-            <h2>Do you have large print versions of your materials, flyers, resources etc?</h2>
-            <p>
+            <h2 tabIndex="0">Do you have large print versions of your materials, flyers, resources etc?</h2>
+            <p tabIndex="0">
                 No. Unfortunately, with this being our first event, this is one level of complexity we won't be covering this year.
             </p>
 
             <a name="audiodescribed"/>
-            <h2>Will you have audio-described resources?</h2>
-            <p>
+            <h2 tabIndex="0">Will you have audio-described resources?</h2>
+            <p tabIndex="0">
                 No. Unfortunately, with this being our first event, this is one level of complexity we won't be covering this year.
             </p>
 
             <a name="captionedtalks"/>
-            <h2>Will talks be captioned?</h2>
-            <p>
+            <h2 tabIndex="0">Will talks be captioned?</h2>
+            <p tabIndex="0">
                 Currently unconfirmed. If the Inclusivity sponsorship option is paid for, then we will be providing captioning, but this is currently still available.
             </p>
         </section>
 
         <section id="dietary">
-            <h1>Dietary/Alchol Concerns</h1>
+            <h1 tabIndex="0">Dietary/Alchol Concerns</h1>
 
             <a name="diet-reqs"/>
-            <h2>Will dietary requirements be catered to?</h2>
-            <p>
+            <h2 tabIndex="0">Will dietary requirements be catered to?</h2>
+            <p tabIndex="0">
                 If you have indicated your dietary requirements in your Eventbrite registration, we will do our best to cater towards them.
             </p>
 
             <a name="food"/>
-            <h2>Are people welcome to bring their own food?</h2>
-            <p>
+            <h2 tabIndex="0">Are people welcome to bring their own food?</h2>
+            <p tabIndex="0">
                 Of course! We completely understand that there are various reasons people may want to bring their own food and drink. We will be catering for vegetarian, vegan and ceoliac dietary requirements at the event as far as we can. 
             </p>
 
             <a name="alcohol"/>
-            <h2>Are people going to be drinking/serving alcohol?</h2>
-            <p>
+            <h2 tabIndex="0">Are people going to be drinking/serving alcohol?</h2>
+            <p tabIndex="0">
                 We won't be providing alcohol at the event.
             </p>
         </section>
 
         <section id="assistanceanimals">
-        <h1>Assistance Animals</h1>
+        <h1 tabIndex="0">Assistance Animals</h1>
 
                 <a name="assistanceanimals"/>
-                <h2>Are assistance animals allowed in the venue?</h2>
-                <p>
+                <h2 tabIndex="0">Are assistance animals allowed in the venue?</h2>
+                <p tabIndex="0">
                     They are yes - but only official assistance dogs.
                 </p>           
         </section>

--- a/pages/about/application-information.js
+++ b/pages/about/application-information.js
@@ -11,9 +11,9 @@ export default () => (
         <Header title={'Application Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
 
-            <p><strong>Applying to Speak</strong></p>
+            <p tabIndex="0"><strong>Applying to Speak</strong></p>
             <ul>
                 <li><a href="#applicationdate">When can I apply to talk?</a></li>
                 <li><a href="#applicationhow">How do I apply to talk?</a></li>
@@ -22,22 +22,22 @@ export default () => (
         </section>
 
         <section id="title">
-                    <h1>Applying to Speak</h1>
+                    <h1 tabIndex="0">Applying to Speak</h1>
         </section>
 
        
         <section id="date">
             <a name="applicationdate"/>
-            <h2>When can I apply to talk?</h2>
-            <p>
+            <h2 tabIndex="0">When can I apply to talk?</h2>
+            <p tabIndex="0">
                 Applications to speak at the 2019 event have closed. 2020 applications open early next year.
             </p>
         </section>
 
         <section id="how">
             <a name="applicationhow"/>
-            <h2>How do I apply to talk?</h2>
-            <p>
+            <h2 tabIndex="0">How do I apply to talk?</h2>
+            <p tabIndex="0">
                 When applications are open <a href="https://sessionize.com/dddeastmidlands/" target="_blank"> you can submit your talk through Sessionize.</a>
             </p>
             <p>
@@ -47,8 +47,8 @@ export default () => (
 
         <section id="tande">
             <a name="tande"/>
-            <h2>Are travel and accomodation expenses provided for speakers?</h2>
-            <p>
+            <h2 tabIndex="0">Are travel and accomodation expenses provided for speakers?</h2>
+            <p tabIndex="0">
                 As we want to encourage local speakers and keep our costs low, we cannot provide expenses (i.e. travel and accomodation costs) to speakers.
             </p> 
         </section>

--- a/pages/about/attendee-information.js
+++ b/pages/about/attendee-information.js
@@ -12,7 +12,7 @@ export default () => (
         <Header title={'Attendee Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
             
             <p><strong><a href="#introduction">Introduction</a></strong></p>
             <p><strong><a href="#code-of-conduct">Code of Conduct</a></strong></p>
@@ -20,27 +20,27 @@ export default () => (
             <p><strong><a href="#age">Age Restrictions</a></strong></p>
             <p><strong><a href="#accessibility">Accessibilty Concerns</a></strong></p>
 
-            <p><strong>Tickets</strong></p>
+            <p tabIndex="0"><strong>Tickets</strong></p>
             <ul>
                 <li><a href="#using-tickets">Using Tickets</a></li>
                 <li><a href="#returning-tickets">Returning Tickets</a></li>
                 <li><a href="#waiting-list">Waiting List</a></li>
             </ul>
-            <p><strong>Before The Day</strong></p>
+            <p tabIndex="0"><strong>Before The Day</strong></p>
             <ul>
                 <li><a href="#pat-before">PAT Testing</a></li>
             </ul>
-            <p><strong>Transport On The Day</strong></p>
+            <p tabIndex="0"><strong>Transport On The Day</strong></p>
             <ul>
                 <li><a href="#train">Taking the train</a></li>
                 <li><a href="#driving">Driving</a></li>
             </ul>
-            <p><strong>Coming To The Event</strong></p>
+            <p tabIndex="0"><strong>Coming To The Event</strong></p>
             <ul>
                 <li><a href="#coffee-meet">Coffee Meet</a></li>
                 <li><a href="#registration">Registration</a></li>
             </ul>
-            <p><strong>Catering</strong></p>
+            <p tabIndex="0"><strong>Catering</strong></p>
             <ul>
                 <li><a href="#food">Food and Dietary Requirements</a></li>
                 <li><a href="#drink">Alcohol</a></li>
@@ -48,7 +48,7 @@ export default () => (
             </ul>
             <p><strong><a href="#wifi">Wifi</a></strong></p>
             <p><strong><a href="#voting">Voting</a></strong></p>
-            <p><strong>Social Media and Photos</strong></p>
+            <p tabIndex="0"><strong>Social Media and Photos</strong></p>
             <ul>
                 <li><a href="#photographs">Photographs</a></li>
                 <li><a href="#social-media">Social Media Posts</a></li>
@@ -64,41 +64,41 @@ export default () => (
         </section>
         
         <section id="introduction">
-        <h1>Introduction</h1> 
+        <h1 tabIndex="0">Introduction</h1> 
             <a name="introduction"/>
-            <h2>Thank you.</h2>
-            <p>
+            <h2 tabIndex="0">Thank you.</h2>
+            <p tabIndex="0">
                 Without your support, there wouldn’t be a DDD East Midlands Conference. Thank you for being an involved and encouraging community.
             </p>
-            <p>
+            <p tabIndex="0">
                 This is going to be a great day full of amazing talks, exhibition stalls and more. We can't wait to meet you all and hope you have a fantastic day.
             </p>
         </section>     
 
         <section id="code-of-conduct">
-        <h1>Code of Conduct</h1> 
+        <h1 tabIndex="0">Code of Conduct</h1> 
             <a name="code-of-conduct"/>
-            <h2>Please familiarise yourself with the Code of Conduct.</h2>
-            <p>
+            <h2 tabIndex="0">Please familiarise yourself with the Code of Conduct.</h2>
+            <p tabIndex="0">
                All involved in the DDD East Midlands Conference are subject to <a href="https://www.dddeastmidlands.com/code-of-conduct/">Code Of Conduct Page.</a> 
                This is not just for the day of the event, but for all presence of DDD East Midlands including Social Media.
             </p>
-            <p>
+            <p tabIndex="0">
                 Please make sure you are familiar with it and adhere to it at all times to create the most inclusive and friendly event for all involved.
             </p>
-            <p>
+            <p tabIndex="0">
                 Should you have any concerns regarding the Code of Conduct before, during or after the event, please contact the organisers. See the <a href="/contact" target="_blank">contact page for information.</a>
             </p>
         </section> 
 
         <section id="where-and-when">
             <a name="when-and-where"/>
-            <h1>When and Where?</h1>
-            <h2>When</h2>
-            <p>
+            <h1 tabIndex="0">When and Where?</h1>
+            <h2 tabIndex="0">When</h2>
+            <p tabIndex="0">
               26th October 2019 8:00am - 6:00pm.
             </p>
-            <h2>Where</h2>
+            <h2 tabIndex="0">Where</h2>
             <p>
                <a href="http://www.nottinghamconferencecentre.co.uk/">The Nottingham Conference Centre</a>
             </p>
@@ -106,39 +106,39 @@ export default () => (
 
         <section id="age-restrictions">
             <a name="age"/>
-            <h1>Age Restrictions</h1>
-            <p>
+            <h1 tabIndex="0">Age Restrictions</h1>
+            <p tabIndex="0">
                 For insurance reasons, only people over the age of 18 can attend DDD East Midlands. We would love to bring this age limit down in the future, but for the first event, we want to keep some of the cost and organisational overhead relatively low.
             </p>
         </section> 
 
         <section id="accessibility">
             <a name="accessibility"/>
-            <h1>Accessibility Concerns</h1>
-            <p>
+            <h1 tabIndex="0">Accessibility Concerns</h1>
+            <p tabIndex="0">
                 We have attempted to answer a number of questions around accessibilty concerns <a href="/about/accessibility-information" targe="_blank">see the accessibilty page for more information.</a>
             </p>
         </section> 
 
         <section id="tickets">
-        <h1>Tickets</h1>            
+        <h1 tabIndex="0">Tickets</h1>            
 
             <a name="using-tickets"/>
-            <h2>Using Tickets</h2>
-            <p>
+            <h2 tabIndex="0">Using Tickets</h2>
+            <p tabIndex="0">
                 We are using Eventbrite for our ticketing. Registration will open from 8am. On entrance one of the crew of volunteers will ask to scan your QR code.
             </p>
             
             <a name="returning-tickets"/>
-            <h2>Returning Tickets</h2>
-            <p>
+            <h2 tabIndex="0">Returning Tickets</h2>
+            <p tabIndex="0">
                 If for any reason you are no longer able to attend the conference, please return your ticket so that someone else can claim the place. We do pay per person, 
                 so this will have an impact on us if you can no longer attend but don't return the ticket. 
             </p>
 
             <a name="waiting-list"/>
-            <h2>Waiting List</h2>
-            <p>
+            <h2 tabIndex="0">Waiting List</h2>
+            <p tabIndex="0">
                 The tickets for this event sold out within a day for both releases. If you were not lucky enough to get a ticket, please 
                 <a href="https://www.eventbrite.co.uk/e/ddd-east-midlands-tickets-58629047058">sign up to the waitlist here</a>. If a ticket becomes available, and you are next on 
                 the waitlist you will recieve an email and given 24 hours to claim your ticket.
@@ -146,27 +146,27 @@ export default () => (
         </section> 
  
         <section id="before-the-day">
-        <h1>Before The Day</h1>            
+        <h1 tabIndex="0">Before The Day</h1>            
             <a name="pat-before"/>
-            <h2>PAT Testing</h2>
-            <p>
+            <h2 tabIndex="0">PAT Testing</h2>
+            <p tabIndex="0">
                 <strong>This point is particularly important if you are taking part in our "Hacktober Corner".</strong>
             </p>
-            <p>
+            <p tabIndex="0">
                 Any devices that will be plugged in during the day need to be PAT tested. They need to have a valid visible sticker on them or a certificate present. 
                 Where possible, please try to get your devices PAT tested before the day. This includes any laptop chargers. 
             </p>
-            <p>
+            <p tabIndex="0">
                There will be a limited amount of PAT testing available on the day. First priority will go to speakers and then to exhibitors.
             </p>
         </section> 
 
         <section id="transport">
-        <h1>Transport On The Day</h1>            
+        <h1 tabIndex="0">Transport On The Day</h1>            
             <a name="train"/>
-            <h2>Taking the train</h2>
-            <h4>Head to Nottingham Train Station</h4>
-            <p>
+            <h2 tabIndex="0">Taking the train</h2>
+            <h4 tabIndex="0">Head to Nottingham Train Station</h4>
+            <p tabIndex="0">
                 Nottingham Station is the mainline train station close to Nottingham city centre. The train station is a
                 15 minute walk from Nottingham Conference Centre, but for those new to the city, it might be easier to
                 take a taxi or use Nottingham’s tram NET (Nottingham Express Transit) system. Directions to the station
@@ -177,103 +177,103 @@ export default () => (
             </p>
             
             <a name="driving"/>
-            <h2>Driving</h2>
-            <h4>Directions to Park and Rides</h4>
-            <p>
+            <h2 tabIndex="0">Driving</h2>
+            <h4 tabIndex="0">Directions to Park and Rides</h4>
+            <p tabIndex="0">
                 From the north, exit the M1 at junction 26 and follow the signs for the A610 towards Nottingham city
                 centre.
             </p>
-            <p>
+            <p tabIndex="0">
                 There is a Park and Ride (tram) facility situated close to the M1 junction 26. The Park and Ride
                 (Phoenix Park) site is clearly sign-posted off the A610. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Leave the tram at the Nottingham Trent University tram stop which is located on Goldsmith Street and walk past the main University entrance,
                 turn left on to Burton Street where you will find the Nottingham Conference Centre entrance. 
             </p>
-            <p>
+            <p tabIndex="0">
                 From the south, exit the M1 at junction 24 and follow the signs for the A453 to Nottingham city centre. 
             </p>
-            <p>
+            <p tabIndex="0">
                 The Queen’s Drive Park and Ride is located just off the A453 (Queen’s Drive), follow signs for A453 /
                 Queen’s Drive Industrial Estate and merge on to the A453 (Queen’s Drive). The Park and Ride is located
                 on the opposite side of the road to the retail park and is clearly sign-posted. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Alight from the Park and Ride bus on Lower Parliament Street (Victoria Centre); Nottingham Conference Centre is a short walk
                 away.
             </p>
             
-            <h4>Car parks</h4>
-            <p>
+            <h4 tabIndex="0">Car parks</h4>
+            <p tabIndex="0">
                 Car parks in the city centre are clearly signposted from all major approach routes. There are two car
                 parks close to Nottingham Conference Centre, Trinity Square car park on North Church Street and Talbot
                 Street car park. For satellite navigation systems please use the following information:
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="http://www.nottinghamcity.gov.uk/transport-parking-and-streets/parking-and-permits/city-centre-parking/car-parks/trinity-square-car-park/" target="_blank">Trinity Square car park:</a></strong> postcode NG1 4BR<br />
                 co-ordinates 52.956785,-1.149316
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="https://www.q-park.co.uk/en-gb/cities/nottingham/talbot-street/" target="_blank">Talbot Street car park:</a></strong> postcode NG1 5GG<br />
                 co-ordinates 52.956143,-1.154433
             </p>
         </section>
 
         <section id="registration">
-        <h1>Coming To The Event</h1>            
+        <h1 tabIndex="0">Coming To The Event</h1>            
             <a name="coffee-meet"/>
-            <h2>Coffee Meet</h2>
-            <p>
+            <h2 tabIndex="0">Coffee Meet</h2>
+            <p tabIndex="0">
                 We know that it isn't always easy to walk into an event alone. One of our volunteers will be at the Costa near the venue to meet those who want to come to the conference with company.
                 They will be heading off from Costa at 8.30 to walk to the venue and get you all signed in.
             </p>
 
             <a name="registration"/>
-            <h2>Registration</h2>
-            <p>
+            <h2 tabIndex="0">Registration</h2>
+            <p tabIndex="0">
                 Registration opens at 8.00am with the opening ceremony starting at 9.00am. You will need your Eventbrite ticket as volunteers will be scanning the QR code.
             </p>
-            <p>
+            <p tabIndex="0">
                 Once you have been scanned in you will be given a lanyard (the colour of which is based on whether you are happy having your photo taken or not) and asked to fill in the information on the front (Name, Pronoun).
             </p>
         </section> 
 
         <section id="catering">
-        <h1>Catering</h1>            
+        <h1 tabIndex="0">Catering</h1>            
             <a name="food"/>
             <h2>Food and Dietary Requirements</h2>
-            <p>
+            <p tabIndex="0">
                 Lunch and snacks will be provided on the day. This will be a hot buffet lunch and the options will be chefs choice on the day.
             </p>
-            <p>
+            <p tabIndex="0">
                 All food is prepared in kitchens where nuts, gluten and other allergens could be present. As the menu descriptions cannot include all ingredients, we will try to cater to the requirements you listed as part of your ticket registration.
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong>Here is an example menu provided by the menu to give you an idea of what might be provided for lunch:</strong>
             </p>
             <p>
                 <ul>
-                    <li>Stir fried vegetables and beans in a Korean style bulgogi sauce</li>
-                    <li>Chicken, leek and mushroom pie topped with shortcrust pastry</li>
-                    <li>Lamb rogan josh served with naan and mango chutney</li>
-                    <li>Parmentier potatoes</li>
-                    <li>Steamed coriander rice</li>
-                    <li>Medley of garden vegetables</li>
-                    <li>Carrot, spring onion and sultana salad</li>
-                    <li>Spiced cous cous</li>
+                    <li tabIndex="0">Stir fried vegetables and beans in a Korean style bulgogi sauce</li>
+                    <li tabIndex="0">Chicken, leek and mushroom pie topped with shortcrust pastry</li>
+                    <li tabIndex="0">Lamb rogan josh served with naan and mango chutney</li>
+                    <li tabIndex="0">Parmentier potatoes</li>
+                    <li tabIndex="0">Steamed coriander rice</li>
+                    <li tabIndex="0">Medley of garden vegetables</li>
+                    <li tabIndex="0">Carrot, spring onion and sultana salad</li>
+                    <li tabIndex="0">Spiced cous cous</li>
                 </ul>
             </p>
 
             <a name="drink"/>
-            <h2>Alcohol</h2>
-            <p>
+            <h2 tabIndex="0">Alcohol</h2>
+            <p tabIndex="0">
                 We will not be serving alcohol as part of the event and ask that you don't bring any with you as we are not licenced.
             </p>
 
             <a name="coffee"/>
-            <h2>Coffee</h2>
-            <p>
+            <h2 tabIndex="0">Coffee</h2>
+            <p tabIndex="0">
                 There is a coffee cart at the event being run by <a href="https://www.cartwheelcoffee.com/" target="_blank">Cartwheel Coffee</a>, thanks to our Sponsors UNiDAYS.
             </p>
 
@@ -281,120 +281,120 @@ export default () => (
 
         <section id="wifi">
         <a name="wifi"/>
-        <h1>Wifi</h1>            
-            <h2>There will be free Wifi on the day</h2>
-            <p>
+        <h1 tabIndex="0">Wifi</h1>            
+            <h2 tabIndex="0">There will be free Wifi on the day</h2>
+            <p tabIndex="0">
                 This is provided by the venue and we will give out details on the day.
             </p>
 
         </section> 
 
         <section id="voting">
-        <h1>Voting</h1> 
+        <h1 tabIndex="0">Voting</h1> 
             <a name="voting"/>
-            <h2>You can vote on talks using a traffic light system.</h2>
-           <p>
+            <h2 tabIndex="0">You can vote on talks using a traffic light system.</h2>
+           <p tabIndex="0">
                During the day there will boxes outside each room for you to put your votes into. All voted will be 
                conducted with a traffic light system:
            </p>
            <ul>
-                <strong><li className="green">Green - That talk was EPIC</li>
-                <li className="yellow">Yellow  - That talk was good</li>
-                <li className="red">Red  - That talk wasn't for me.</li></strong>
+                <strong><li tabIndex="0" className="green">Green - That talk was EPIC</li>
+                <li tabIndex="0" className="yellow">Yellow  - That talk was good</li>
+                <li tabIndex="0" className="red">Red  - That talk wasn't for me.</li></strong>
             </ul>
-            <p>
+            <p tabIndex="0">
                 This is mostly so we can see which talks have a good reception to help us plan for our future events.
             </p>
         </section> 
 
         <section id="social-media">
-        <h1>Social Media and Photos</h1>
-            <p>
+        <h1 tabIndex="0">Social Media and Photos</h1>
+            <p tabIndex="0">
                 Feel free to take photos and post on social media before, after and during the event. There are just a few guidelines we ask you to respect.
             </p> 
             <a name="photographs"/>
-            <h2>Photographs</h2>
-            <p>
+            <h2 tabIndex="0">Photographs</h2>
+            <p tabIndex="0">
                 We will have a coloured lanyard system at the event to indicate whether attendees are OK with their photo being taken and used.
             </p>
             <ul>
-                <li className="green">Green — It’s fine for their photo to be taken</li>
-                <li className="red">Red — Do not include me in your photos or promotional material</li>
+                <li tabIndex="0" className="green">Green — It’s fine for their photo to be taken</li>
+                <li  tabIndex="0" className="red">Red — Do not include me in your photos or promotional material</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 You will be able to pick your lanyard on registration.
             </p>
             <a name="social-media"/>
-            <h2>Social Media Posts</h2>
-            <p>
+            <h2 tabIndex="0">Social Media Posts</h2>
+            <p tabIndex="0">
                 Please use any of the below information to tag us. If using our hashtag or handles though, please avoid promoting 
                 anything that doesn’t align with our code of conduct.
             </p>
-            <h3>DDD East Midlands on Social Media</h3>
-            <ul>Hashtags:   #DDDEM   |    #DDDEM2019</ul>
-            <ul>Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
-            <ul>LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
-            <ul>Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
+            <h3 tabIndex="0">DDD East Midlands on Social Media</h3>
+            <ul tabIndex="0">Hashtags:   #DDDEM   |    #DDDEM2019</ul>
+            <ul tabIndex="0">Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
+            <ul tabIndex="0">LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
+            <ul tabIndex="0">Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
         </section> 
 
 
         <section id="pubconf">
-        <h1>PubConf - The Unofficial After Party</h1> 
+        <h1 tabIndex="0">PubConf - The Unofficial After Party</h1> 
 
              <a name="after-party-about"/>
-            <h2>About</h2>
-            <p>
+            <h2 tabIndex="0">About</h2>
+            <p tabIndex="0">
                 After the conference, there will be a special <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf</a> featuring some of our speakers and special guests. This 
                 evening event has comedy talks, music, food and beverages. It's great fun for all and we encourage you to come along.
             </p>
             <p>
-                <strong>Quick about:</strong>
+                <h4 tabIndex="0">Quick about:</h4>
                 <ul>
-                    <li>
+                    <li tabIndex="0">
                         The talks conducted at PubConf are 5 minute, comedy ignite talks:
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         20 slides timed to increment every 15 seconds. The speakers have no control
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         The top three talks will go into a final battle to win prizes. These three finalists will be presented 
                         with a ignite deck they have never seen before and given a topic. They will then have to come up with an 
                         impromptu talk on the spot.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         Talk topics have an emphasis on humour. Often the content is not suitable to be shared away 
                         from the safety of PubConf.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         PubConf is a separate entity and business from DDD East Midlands. As such they have their own 
                         Code of Conduct. Hence "Unofficial" after party. We are not involved in its organisation.
                     </li>
                 </ul>
             </p>
-            <p>
+            <p tabIndex="0">
                 This is the first PubConf in the UK outside of London and it's going to be brilliant.
             </p>
 
              <FullWidthImage url={'/static/banners/pubconf.png'}/>
 
             <a name="after-party-rules"/>
-            <h2>Rules of PubConf</h2>
+            <h2 tabIndex="0">Rules of PubConf</h2>
             <p>
-                <strong>What happens at PubConf, stays at Pubconf.</strong>
+                <h4 tabIndex="0">What happens at PubConf, stays at Pubconf.</h4>
                 <ul>
-                    <li>No photos or videos unless you have the speakers explicit permission.</li>
-                    <li>No quoting talks. (Taken out of context, a joke can be damaging)</li>
+                    <li tabIndex="0">No photos or videos unless you have the speakers explicit permission.</li>
+                    <li tabIndex="0">No quoting talks. (Taken out of context, a joke can be damaging)</li>
                 </ul>
-                <strong>This is an event for over 18's as there will be alcohol present.</strong>
+                <h4 tabIndex="0">This is an event for over 18's as there will be alcohol present.</h4>
             </p>
 
              <a name="pubconf-tickets"/>
-            <h2>Be alerted about tickets</h2>
-            <p>
+            <h2 tabIndex="0">Be alerted about tickets</h2>
+            <p tabIndex="0">
                 Go to the <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf website</a> to find out more and 
                 sign up for an email alert when tickets are released.
             </p>
-            <p>
+            <p tabIndex="0">
                 Anyone can buy a ticket to PubConf, even if they aren't attending the DDD East Midlands conference.
             </p>
          </section>

--- a/pages/about/speaker-information.js
+++ b/pages/about/speaker-information.js
@@ -288,8 +288,8 @@ export default () => (
                 We will have a coloured lanyard system at the event to indicate whether attendees are OK with their photo being taken and used.
             </p>
             <ul>
-                <li tabIndex="0" className="green"><strong>Green — It’s fine for their photo to be taken</strong></li>
-                <li tabIndex="0" className="red"><strong>Red — Do not include me in your photos or promotional material</strong></li>
+                <li tabIndex="0" className="green">Green — It’s fine for their photo to be taken</li>
+                <li tabIndex="0" className="red">Red — Do not include me in your photos or promotional material></li>
             </ul>
             <p tabIndex="0">
                 We ask that you please respect this system and only use photos that have attendees with green lanyards only.

--- a/pages/about/speaker-information.js
+++ b/pages/about/speaker-information.js
@@ -12,27 +12,27 @@ export default () => (
         <Header title={'Speaker Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
 
             <p><strong><a href="#introduction">Introduction</a></strong></p>
 
             <p><strong><a href="#code-of-conduct">Code of Conduct</a></strong></p>
             
-            <p><strong>General</strong></p>
+            <p tabIndex="0"><strong>General</strong></p>
             <ul>
                 <li><a href="#rooms">Rooms</a></li>
                 <li><a href="#tech"> Available Tech</a></li>
             </ul>
             
-            <p><strong>Before The Conference</strong></p>
+            <p tabIndex="0"><strong>Before The Conference</strong></p>
             <ul>
                 <li><a href="#we-need-to-know">What we need to know</a></li>
                 <li><a href="#what-to-prepare">What to prepare</a></li>
             </ul>
 
-            <p><strong><a href="#voting">Voting</a></strong></p>
+            <p ><strong><a href="#voting">Voting</a></strong></p>
 
-            <p><strong>The Day Of The Conference</strong></p>
+            <p tabIndex="0"><strong>The Day Of The Conference</strong></p>
             <ul>
                 <li><a href="#conference-arrival">Letting us know you have arrived</a></li>
                 <li><a href="#pat-testing">PAT Testing</a></li>
@@ -42,19 +42,19 @@ export default () => (
                 <li><a href="#q-and-a">Q and A space</a></li>
             </ul>
 
-            <p><strong>Social Media and Photos</strong></p>
+            <p tabIndex="0"><strong>Social Media and Photos</strong></p>
             <ul>
                 <li><a href="#photographs">Photographs</a></li>
                 <li><a href="#instagram">Instagram Stories</a></li>
                 <li><a href="#social-posts">Social Media Posts</a></li>
             </ul>
 
-            <p><strong>After The Conference Media</strong></p>
+            <p tabIndex="0"><strong>After The Conference Media</strong></p>
             <ul>
                 <li><a href="#talk-videos">Videoed Talks</a></li>
             </ul>
 
-            <p><strong>PubConf - The Unofficial After Party</strong></p>
+            <p tabIndex="0"><strong>PubConf - The Unofficial After Party</strong></p>
             <ul>
                 <li><a href="#after-party-about">About</a></li>
                 <li><a href="#after-party-rules">Rules of PubConf</a></li>
@@ -64,14 +64,14 @@ export default () => (
 
             <p><strong><a href="#checklist">Suggested Checklist</a></strong></p>
 
-            <p><strong>Transport</strong></p>
+            <p tabIndex="0"><strong>Transport</strong></p>
             <ul>
                 <li><a href="#train">Taking the train</a></li>
                 <li><a href="#driving">Driving</a></li>
                 <li><a href="#air">By Air</a></li>
             </ul>
 
-            <p><strong>Staying in Nottingham</strong></p>
+            <p tabIndex="0"><strong>Staying in Nottingham</strong></p>
             <ul>
                 <li><a href="#important-contacts">Important Contacts</a></li>
                 <li><a href="#hotels">Hotels</a></li>
@@ -80,118 +80,112 @@ export default () => (
         </section>
                       
         <section id="introduction">
-        <h1>Introduction</h1> 
+        <h1 tabIndex="0">Introduction</h1> 
             <a name="introduction"/>
-            <h2>Thank you.</h2>
-            <p>
+            <h2 tabIndex="0">Thank you.</h2>
+            <p tabIndex="0">
                 Without your support and effort, there wouldn’t be a DDD East Midlands event at all. This page outlines what you need to know on the day. 
             </p>
         </section>     
 
         <section id="code-of-conduct">
-        <h1>Code of Conduct</h1> 
+        <h1 tabIndex="0">Code of Conduct</h1> 
             <a name="code-of-conduct"/>
-            <h2>Please familiarise yourself with the Code of Conduct.</h2>
-            <p>
+            <h2 tabIndex="0">Please familiarise yourself with the Code of Conduct.</h2>
+            <p tabIndex="0">
                All involved in the DDD East Midlands Conference are subject to the <a href="https://www.dddeastmidlands.com/code-of-conduct/">Code Of Conduct.</a> 
                This is not just for the day of the event, but for all presence of DDD East Midlands including Social Media.
             </p>
-            <p>
+            <p tabIndex="0">
                 Please make sure you are familiar with it and adhere to it at all times to create the most inclusive and friendly event for all involved.
             </p>
-            <p>
+            <p tabIndex="0">
                 Should you have any concerns regarding the Code of Conduct before, during or after the event, please contact the organisers. See the <a href="/contact" target="_blank">contact page for information.</a>
             </p>
         </section>
 
         <section id="general">
-        <h1>General</h1> 
+        <h1 tabIndex="0">General</h1> 
             <a name="rooms"/>
-            <h2>Rooms</h2>
+            <h2 tabIndex="0">Rooms</h2>
         
-            <h4>Room 1 (Lecture Theatre 2)</h4>
+            <h4 tabIndex="0">Room 1 (Lecture Theatre 2)</h4>
             <FullWidthImage url={'/static/rooms/LT2.png'}/>
-            <p>
-                <ul>
-                    <strong>Seats:</strong> up to 470 people
-                </ul>
+            <p tabIndex="0">
+                <strong>Seats:</strong> up to 470 people
             </p>
 
-            <h4>Room 2 (Lecture Theatre 4)</h4>
+            <h4 tabIndex="0">Room 2 (Lecture Theatre 4)</h4>
             <FullWidthImage url={'/static/rooms/LT4.png'}/>
-            <p>
-                <ul>
-                    <strong>Seats:</strong> up to 100 people
-                </ul>
+            <p tabIndex="0">
+                <strong>Seats:</strong> up to 100 people
             </p>
 
-            <h4>Room 3 (Lecture Theatre 5)</h4>
+            <h4 tabIndex="0">Room 3 (Lecture Theatre 5)</h4>
             <FullWidthImage url={'/static/rooms/LT5.png'}/>            
-            <p>
-                <ul>
-                    <strong>Seats:</strong> up to 100 people
-                </ul>
+            <p tabIndex="0">
+                <strong>Seats:</strong> up to 100 people
             </p>
             
             <a name="tech"/>
-            <h2>Available Tech</h2>
+            <h2 tabIndex="0">Available Tech</h2>
 
-            <h4>Screen sizes/aspect ratio</h4>
-            <p>
+            <h4 tabIndex="0">Screen sizes/aspect ratio</h4>
+            <p tabIndex="0">
                 All of these screens are widescreen and are a mixture of 16:9 or 16:10 aspect ratio.
             </p>
-            <h4>Adaptors (HDMI etc)</h4>
-            <p>
+            <h4 tabIndex="0">Adaptors (HDMI etc)</h4>
+            <p tabIndex="0">
                 All rooms have wireless capabilities for MAC and PC, they also have both HDMI and VGA adaptors.
                 The main lecture theatre (Room 1/Lecture Theatre 2) has all of the above plus Mini Display Port and Mini HDMI. 
                 There is also a visualizer available in each Lecture Theatre.
             </p>
-            <h4>Microphones</h4>
-            <p>
+            <h4 tabIndex="0">Microphones</h4>
+            <p tabIndex="0">
                 All rooms have the choice of clip-on, static or hand held microphones. Please let your AV support person/volunteer know if you have a preference.
             </p>
-            <h4>Wi-Fi</h4>
-            <p>
+            <h4 tabIndex="0">Wi-Fi</h4>
+            <p tabIndex="0">
                 We will email the Wi-Fi details shortly before the event.
             </p>
         </section>
 
         <section id="before">
-        <h1>Before The Conference</h1> 
+        <h1 tabIndex="0">Before The Conference</h1> 
 
             <a name="we-need-to-know"/>
-            <h2>What we need to know</h2>
-            <li>Is there sound/video in your presentation?</li>
+            <h2 tabIndex="0">What we need to know</h2>
+            <li tabIndex="0">Is there sound/video in your presentation?</li>
 
             <a name="what-to-prepare"/>
-            <h2>What to prepare</h2>
-            <li>A copy of your presentation on a usb stick</li>
-            <li>A clicker</li>
-            <li>If possible, get any electricals you will need on the day PAT Tested.</li>
+            <h2 tabIndex="0">What to prepare</h2>
+            <li tabIndex="0">A copy of your presentation on a usb stick</li>
+            <li tabIndex="0">A clicker</li>
+            <li tabIndex="0">If possible, get any electricals you will need on the day PAT Tested.</li>
         </section>
 
         <section id="voting">
-        <h1>Voting</h1> 
+        <h1 tabIndex="0">Voting</h1> 
             <a name="voting"/>
-            <h2>Attendees can vote using a traffic light system.</h2>
-           <p>
+            <h2 tabIndex="0">Attendees can vote using a traffic light system.</h2>
+           <p tabIndex="0">
                During the day there will boxes outside each room for attendees to put their votes into. All votes will be 
                conducted with a traffic light system:
            </p>
            <ul>
-                <strong><li className="green">Green - That talk was EPIC</li>
-                <li className="yellow">Yellow  - That talk was good</li>
-                <li className="red">Red  - That talk wasn't for me.</li></strong>
+                <strong><li tabIndex="0" className="green">Green - That talk was EPIC</li>
+                <li tabIndex="0" className="yellow">Yellow  - That talk was good</li>
+                <li tabIndex="0" className="red">Red  - That talk wasn't for me.</li></strong>
             </ul>
-            <p>
+            <p tabIndex="0">
                 There are a couple of reasons we have this voting system in place:
             </p>
             <ul>
-                <li>
+                <li tabIndex="0">
                     <strong>To give our speakers some light indication around the reception of their talks.</strong> We cannot offer more in-depth means of feedback this 
                     year as it would require a level of moderation and work that, unfortunately, we don't have the time to invest in this first year.
                 </li>
-                <li>
+                <li tabIndex="0">
                     <strong>To give us an indication of which subject areas are of particular interest in the local area.</strong> This is not for any future talk 
                     curation, but to give us more knowledge about the local area so that we can help our sponsors target their efforts appropriately, 
                     and to aid us in our own marketing efforts.
@@ -200,110 +194,110 @@ export default () => (
         </section>
 
         <section id="day-of">
-        <h1>The Day Of The Conference</h1> 
+        <h1 tabIndex="0">The Day Of The Conference</h1> 
             <a name="conference-arrival"/>
-            <h2>Letting us know you have arrived</h2>
-            <h4>Check in at registration and come say hi at the information desk.</h4>
-            <p>
+            <h2 tabIndex="0">Letting us know you have arrived</h2>
+            <h4 tabIndex="0">Check in at registration and come say hi at the information desk.</h4>
+            <p tabIndex="0">
                 At least one of the organisers will be at the registration desk in the morning.
             </p>
 
             <a name="pat-testing"/>
-            <h2>PAT Testing</h2>
-            <h4>If you can, get any devices that will be plugged in PAT tested before the event.</h4>
-            <p>            
+            <h2 tabIndex="0">PAT Testing</h2>
+            <h4 tabIndex="0">If you can, get any devices that will be plugged in PAT tested before the event.</h4>
+            <p tabIndex="0">            
                 Due to venue insurance restrictions, we need to be sure that anything that may be plugged 
                 into a socket on the day <strong>either:</strong>
             </p>
             <ul>
-                <li>Has a current PAT test sticker/certificate</li>
-                <li>Is less than one year old. Please ensure that where electrical items are less than a year old, evidence of this is provided.</li>
+                <li tabIndex="0">Has a current PAT test sticker/certificate</li>
+                <li tabIndex="0">Is less than one year old. Please ensure that where electrical items are less than a year old, evidence of this is provided.</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 This includes any laptop chargers or phone chargers.
             </p>
-            <p>
+            <p tabIndex="0">
                 We will provide limited PAT testing on the day, with speakers being priority candidates for this service.
                 This service will be available between <strong>7.30am - 9.30am the day of the conference</strong>. Registration for the 
                 event opens to the general public at 8.00am so there is a window in the morning where exclusively speakers and exhibitors can 
                 queue to get their devices PAT tested.
             </p>
-            <p>
+            <p tabIndex="0">
                 If you will need your laptop cables PAT tested but cannot make it to the venue between those hours, contact Jessica to arrange 
                 dropping off your chargers the evening before.
             </p>
 
             <a name="green-room"/>
-            <h2>Green Room</h2>
-            <h4>There is a room for speakers to get some space.</h4>
-            <p>
+            <h2 tabIndex="0">Green Room</h2>
+            <h4 tabIndex="0">There is a room for speakers to get some space.</h4>
+            <p tabIndex="0">
                 On the day there will be a speakers green room. Here you can practice or prepare for your talk, or just get some peace away 
                 from the hustle and bustle of the conference.
             </p>
-            <p>
+            <p tabIndex="0">
                <strong>Try out the visualiser</strong> 
             </p>
-            <p>
+            <p tabIndex="0">
                 A visualiser will be set up in the Speakers Green Room so that you can try it out before you do your talk.
             </p>
 
             <a name="room-arrival"/>
-            <h2>Arriving at the room</h2>
+            <h2 tabIndex="0">Arriving at the room</h2>
             
-            <h4>Please arrive 10 - 15 minutes before your presentation.</h4>
-            <p>
+            <h4 tabIndex="0">Please arrive 10 - 15 minutes before your presentation.</h4>
+            <p tabIndex="0">
                 This is so that there is enough time to get you all set up.
             </p>
             
             <h4>Introduce yourself to the crew member looking after your room.</h4>
-            <p>
+            <p tabIndex="0">
                 The crew member will make sure there is water, and will be happy to help you with your presentation
                 needs. They will also help us make sure everything is running smoothly in your room. Please let them know 
                 if there is anything we can provide to help you.
             </p>
             
-            <h4>Meet the AV technician and get Mic'd up</h4>
-            <p>
+            <h4 tabIndex="0">Meet the AV technician and get Mic'd up</h4>
+            <p tabIndex="0">
                 There are a variety of microphones available in each room. Clip-on, static and hand held are available, so 
                 please let the technicians know if you have a preference.
             </p>
             <a name="clickers"/>
-            <h2>Clickers</h2>
-            <h4>You can bring your own clicker or we can provide one.</h4>
-            <p>
+            <h2 tabIndex="0">Clickers</h2>
+            <h4 tabIndex="0">You can bring your own clicker or we can provide one.</h4>
+            <p tabIndex="0">
                 We can provide 3 clickers for the day (one per room). So if you do use one of the clickers provided, please
                 make sure it stays in the room for the next speaker who might need it.
             </p>
             <a name="q-and-a"/>
-            <h2>Q and A space</h2>
-            <h4>Want a place where people can approach you with their questions after your talk?</h4>
-            <p>
+            <h2 tabIndex="0">Q and A space</h2>
+            <h4 tabIndex="0">Want a place where people can approach you with their questions after your talk?</h4>
+            <p tabIndex="0">
                 We'll provide a space in the breakout area with a table and chair. Book in a time slot with Jessica, and you can advertise
                 during or at the end of your talk that you will be available there to be approached by attendees after your talk.
             </p>
         </section>
 
         <section id="social-media">
-        <h1>Social Media and Photos</h1>
-            <p>
+        <h1 tabIndex="0">Social Media and Photos</h1>
+            <p tabIndex="0">
                 Feel free to take photos and post on social media before, after and during the event. There are just a few guidelines we ask you to respect.
             </p> 
             <a name="photographs"/>
-            <h2>Photographs</h2>
-            <p>
+            <h2 tabIndex="0">Photographs</h2>
+            <p tabIndex="0">
                 We will have a coloured lanyard system at the event to indicate whether attendees are OK with their photo being taken and used.
             </p>
             <ul>
-                <li className="green">Green — It’s fine for their photo to be taken</li>
-                <li className="red">Red — Do not include me in your photos or promotional material</li>
+                <li tabIndex="0" className="green"><strong>Green — It’s fine for their photo to be taken</strong></li>
+                <li tabIndex="0" className="red"><strong>Red — Do not include me in your photos or promotional material</strong></li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 We ask that you please respect this system and only use photos that have attendees with green lanyards only.
             </p>
 
             <a name="instagram"/>
-            <h2>Instagram Stories</h2>
-            <p>
+            <h2 tabIndex="0">Instagram Stories</h2>
+            <p tabIndex="0">
                 As part of the first event, we are going to have some select volunteers run a couple of our social media accounts. 
                 If you would not mind appearing on our Instagram stories with a short video of what you have thought about the event 
                 and your experience of taking part, please let us know so our helpful volunteers can meet you at the Q and A space to record 
@@ -311,90 +305,90 @@ export default () => (
             </p>
 
             <a name="social-media"/>
-            <h2>Social Media Posts</h2>
-            <p>
+            <h2 tabIndex="0">Social Media Posts</h2>
+            <p tabIndex="0">
                 Please use any of the below information to tag us. If using our hashtag or handles though, please avoid promoting 
                 anything that doesn’t align with our code of conduct.
             </p>
-            <h3>DDD East Midlands on Social Media</h3>
-            <ul>Hashtags:   #DDDEM   |    #DDDEM2019</ul>
-            <ul>Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
-            <ul>LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
-            <ul>Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
+            <h3 tabIndex="0">DDD East Midlands on Social Media</h3>
+            <ul tabIndex="0">Hashtags:   #DDDEM   |    #DDDEM2019</ul>
+            <ul tabIndex="0">Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
+            <ul tabIndex="0">LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
+            <ul tabIndex="0">Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
 
         </section> 
 
         <section id="after">
-        <h1>After The Conference Media</h1> 
+        <h1 tabIndex="0">After The Conference Media</h1> 
             <a name="talk-videos"/>
-            <h2>Videoed Talks</h2>
-            <p>
+            <h2 tabIndex="0">Videoed Talks</h2>
+            <p tabIndex="0">
                 All the talks are being videoed by the local company ShutterSocks. These will be posted on Vimeo as soon as they are available. There are a few reasons we are videoing the talks:
             </p>
-            <li>For future conference submissions. Often conference submissions are strengthened with the evidence of your presentation skills.</li>
-            <li>To keep the conversation going after the conference. Your talks can be shared with all those who might find them useful.</li>
+            <li tabIndex="0">For future conference submissions. Often conference submissions are strengthened with the evidence of your presentation skills.</li>
+            <li tabIndex="0">To keep the conversation going after the conference. Your talks can be shared with all those who might find them useful.</li>
         </section>
 
 
         <section id="pubconf">
-        <h1>PubConf - The Unofficial After Party</h1> 
+        <h1 tabIndex="0">PubConf - The Unofficial After Party</h1> 
 
             <a name="after-party-about"/>
-            <h2>About</h2>
-            <p>
+            <h2 tabIndex="0">About</h2>
+            <p tabIndex="0">
                 After the conference, there will be a special <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf</a> featuring some of our speakers and special guests. This 
                 evening event has comedy talks, music, food and beverages. It's great fun for all and we encourage you to come along.
             </p>
             <p>
-                <strong>Quick about:</strong>
+                <h4 tabIndex="0">Quick about:</h4>
                 <ul>
-                    <li>
+                    <li tabIndex="0">
                         The talks conducted at PubConf are 5 minute, comedy ignite talks:
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         20 slides timed to increment every 15 seconds. The speakers have no control
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         The top three talks will go into a final battle to win prizes. These three finalists will be presented 
                         with a ignite deck they have never seen before and given a topic. They will then have to come up with an 
                         impromptu talk on the spot.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         Talk topics have an emphasis on humour. Often the content is not suitable to be shared away 
                         from the safety of PubConf.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         PubConf is a separate entity and business from DDD East Midlands. As such they have their own 
                         Code of Conduct. Hence "Unofficial" after party. We are not involved in its organisation.
                     </li>
                 </ul>
             </p>
-            <p>
+            <p tabIndex="0">
                 This is the first PubConf in the UK outside of London and it's going to be brilliant.
             </p>
             
             <FullWidthImage url={'/static/banners/pubconf.png'}/>
 
             <a name="after-party-rules"/>
-            <h2>Rules of PubConf</h2>
+            <h2 tabIndex="0">Rules of PubConf</h2>
             <p>
-                <strong>What happens at PubConf, stays at Pubconf.</strong>
+                <h4 tabIndex="0">What happens at PubConf, stays at Pubconf.</h4>
                 <ul>
-                    <li>No photos or videos unless you have the speakers explicit permission.</li>
-                    <li>No quoting talks. (Taken out of context, a joke can be damaging)</li>
+                    <li tabIndex="0">No photos or videos unless you have the speakers explicit permission.</li>
+                    <li tabIndex="0">No quoting talks. (Taken out of context, a joke can be damaging)</li>
                 </ul>
             </p>
 
             <a name="pubconf-tickets"/>
-            <h2>Be alerted about tickets</h2>
-            <p>
+            <h2 tabIndex="0">Be alerted about tickets</h2>
+            <p tabIndex="0">
                 Go to the <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf website</a> to find out more and 
                 sign up for an email alert when tickets are released.
             </p>
 
             <a name="speak-pubconf"/>
-            <h2>Fancy giving it a shot?</h2>
-            <p>
+            <h2 tabIndex="0">Fancy giving it a shot?</h2>
+            <p tabIndex="0">
                 Dylan Beattie is organising PubConf Nottingham. If you are a speaker and are interested in taking part (it's a great challenge 
                 and a lot of fun) do the following:
             </p>
@@ -402,42 +396,42 @@ export default () => (
                <li>
                    <a href="https://www.technottingham.com/slack" target="_blank">Join the Tech Nottingham Slack Group</a>
                </li>
-               <li>
+               <li tabIndex="0">
                    Join the channel #pubconf or DM Dylan Beattie
                </li>
-               <li>
+               <li tabIndex="0">
                    Send Dylan a photo, talk title and tagline for yourself.
                </li>
            </ul>
-           <p>
+           <p tabIndex="0">
                See an example of a previous PubConf talk <a href="https://youtu.be/USmUlshjcd4" target="_blank">here</a>
             </p>
 
         </section>
 
         <section id="checklist">
-        <h1>Suggested Checklist</h1> 
-            <li>Twitter handle on slides</li>
-            <li>Clicker</li>
-            <li>Backup of slides</li>
-            <li>Laptop charger</li>
-            <li>Timer</li>
-            <li>The awesome <a href="https://open.spotify.com/playlist/0kTPxCiWN0kyYa8FSWpdi2?" target="_blank">Get Pumped Playlist</a></li>
+        <h1 tabIndex="0">Suggested Checklist</h1> 
+            <li tabIndex="0">Twitter handle on slides</li>
+            <li tabIndex="0">Clicker</li>
+            <li tabIndex="0">Backup of slides</li>
+            <li tabIndex="0">Laptop charger</li>
+            <li tabIndex="0">Timer</li>
+            <li tabIndex="0">The awesome <a href="https://open.spotify.com/playlist/0kTPxCiWN0kyYa8FSWpdi2?" target="_blank">Get Pumped Playlist</a></li>
 
-            <h4>Our favourite available list</h4>
-            <p>
+            <h4 tabIndex="0">Our favourite available list</h4>
+            <p tabIndex="0">
                 <a href="https://csswizardry.com/2016/06/speakers-checklist-before-and-after-your-talk/" target="_blank">This list by csswizardry</a> 
                 is often used by us at other events. Thank you <a href="https://twitter.com/Brunty" target="_blank">Brunty</a> for sharing this with us.
             </p>
         </section>
 
         <section id="transport">
-        <h1>Transport</h1> 
+        <h1 tabIndex="0">Transport</h1> 
             
             <a name="train"/>
-            <h2>Taking the train</h2>
-            <h4>Head to Nottingham Train Station</h4>
-            <p>
+            <h2 tabIndex="0">Taking the train</h2>
+            <h4 tabIndex="0">Head to Nottingham Train Station</h4>
+            <p tabIndex="0">
                 Nottingham Station is the mainline train station close to Nottingham city centre. The train station is a
                 15 minute walk from Nottingham Conference Centre, but for those new to the city, it might be easier to
                 take a taxi or use Nottingham’s tram NET (Nottingham Express Transit) system. Directions to the station
@@ -448,52 +442,52 @@ export default () => (
             </p>
 
             <a name="driving"/>
-            <h2>Driving</h2>
-            <h4>Directions to Park and Rides</h4>
-            <p>
+            <h2 tabIndex="0">Driving</h2>
+            <h4 tabIndex="0">Directions to Park and Rides</h4>
+            <p tabIndex="0"> 
                 From the north, exit the M1 at junction 26 and follow the signs for the A610 towards Nottingham city
                 centre.
             </p>
-            <p>
+            <p tabIndex="0">
                 There is a Park and Ride (tram) facility situated close to the M1 junction 26. The Park and Ride
                 (Phoenix Park) site is clearly sign-posted off the A610. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Leave the tram at the Nottingham Trent University tram stop which is located on Goldsmith Street and walk past the main University entrance,
                 turn left on to Burton Street where you will find the Nottingham Conference Centre entrance. 
             </p>
-            <p>
+            <p tabIndex="0">
                 From the south, exit the M1 at junction 24 and follow the signs for the A453 to Nottingham city centre. 
             </p>
-            <p>
+            <p tabIndex="0">
                 The Queen’s Drive Park and Ride is located just off the A453 (Queen’s Drive), follow signs for A453 /
                 Queen’s Drive Industrial Estate and merge on to the A453 (Queen’s Drive). The Park and Ride is located
                 on the opposite side of the road to the retail park and is clearly sign-posted. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Alight from the Park and Ride bus on Lower Parliament Street (Victoria Centre); Nottingham Conference Centre is a short walk
                 away.
             </p>
 
-            <h4>Car parks</h4>
-            <p>
+            <h4 tabIndex="0">Car parks</h4>
+            <p tabIndex="0">
                 Car parks in the city centre are clearly signposted from all major approach routes. There are two car
                 parks close to Nottingham Conference Centre, Trinity Square car park on North Church Street and Talbot
                 Street car park. For satellite navigation systems please use the following information:
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="http://www.nottinghamcity.gov.uk/transport-parking-and-streets/parking-and-permits/city-centre-parking/car-parks/trinity-square-car-park/" target="_blank">Trinity Square car park:</a></strong> postcode NG1 4BR<br />
                 co-ordinates 52.956785,-1.149316
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="https://www.q-park.co.uk/en-gb/cities/nottingham/talbot-street/" target="_blank">Talbot Street car park:</a></strong> postcode NG1 5GG<br />
                 co-ordinates 52.956143,-1.154433
             </p>
 
             <a name="air"/>
-            <h2>By Air</h2>
-            <h4>From East Midlands Airport</h4>
-            <p>
+            <h2 tabIndex="0">By Air</h2>
+            <h4 tabIndex="0">From East Midlands Airport</h4>
+            <p tabIndex="0">
                 The closest airport to Nottingham is East Midlands Airport which is 15 miles (approximately 24
                 kilometres) outside of the city. It takes about half an hour from there to travel into the city by car
                 or bus. There is a Skylink bus service that runs every half hour from the airport into Nottingham city
@@ -502,48 +496,48 @@ export default () => (
         </section>
 
         <section id="nottingham">
-        <h1>Staying in Nottingham</h1> 
+        <h1 tabIndex="0">Staying in Nottingham</h1> 
 
             <a name="important-contacts"/>
-            <h2>Important Contacts</h2>
-            <h4>Conference</h4>
-            <p>
-                <li><strong>Co-organiser Jessica White:</strong></li>
-                    <p>Tel: number will be emailed to you </p>
-                    <p>Email: jessica@dddeastmidlands.com </p>
-                    <li><strong>Co-organiser Moreton Brockley:</strong></li> 
-                    <p>Email: moreton@dddeastmidlands.com</p>
-            </p>
+            <h2 tabIndex="0">Important Contacts</h2>
+            <h4 tabIndex="0">Conference</h4>
+            <ul>
+                <li tabIndex="0"><strong>Co-organiser Jessica White:</strong></li>
+                    <p tabIndex="0">Tel: number will be emailed to you </p>
+                    <p tabIndex="0">Email: jessica@dddeastmidlands.com </p>
+                <li tabIndex="0"><strong>Co-organiser Moreton Brockley:</strong></li> 
+                    <p tabIndex="0">Email: moreton@dddeastmidlands.com</p>
+            </ul>
 
             <a name="hotels"/>
-            <h2>Hotels</h2>
-            <p>We don't have any partnerships or deals with any local hotels but here is a list of a few in City Center:</p>
+            <h2 tabIndex="0">Hotels</h2>
+            <p tabIndex="0">We don't have any partnerships or deals with any local hotels but here is a list of a few in City Center:</p>
             <li><a href="https://www.ihg.com/crowneplaza/hotels/gb/en/nottingham/notws/hoteldetail?cm_mmc=GoogleMaps-_-CP-_-GB-_-NOTWS" target="_blank">Crowne Plaza</a></li>
             <li><a href="https://www.accorhotels.com/gb/hotel-6160-ibis-nottingham-centre/index.shtml" target="_blank">Ibis</a></li>
             <li><a href="https://www.roomzzz.com/locations/nottingham/" target="_blank">Roomzzz</a></li>
             <li><a href="https://www.mercurenottingham.com/" target="_blank">Mercure</a></li>
 
             <a name="restaurants"/>
-            <h2>Restaurants</h2>
-            <h4>Coffee</h4>
+            <h2 tabIndex="0">Restaurants</h2>
+            <h4 tabIndex="0">Coffee</h4>
             <li><a href="https://www.cartwheelcoffee.com/" target="_blank">Cartwheel</a></li>
             <li><a href="https://www.outpost.coffee/" target="_blank">Outpost</a></li>
             <li><a href="https://200degs.com/" target="_blank">200 Degrees</a></li>
             <li><a href="https://www.thespecialtycoffeeshop.com/" target="_blank">Speciality</a></li>
 
 
-            <h4>Breakfast</h4>
+            <h4 tabIndex="0">Breakfast</h4>
             <li><a href="https://anniesburgershack.com/menu/breakfast-menu" target="_blank">Annies Burger Shack</a></li>
             <li><a href="https://www.thepuddingpantry.co.uk/breakfast" target="_blank">Pudding Pantry</a></li>
             
-            <h4>Dinner</h4>
+            <h4 tabIndex="0">Dinner</h4>
             <li><a href="http://www.oscarandrosies.com/menu" target="_blank">Oscar And Rosies</a></li>
             <li><a href="https://anniesburgershack.com/menu/main-menu" target="_blank">Annies Burger Shack</a></li>
             <li><a href="https://www.tripadvisor.co.uk/Restaurant_Review-g186356-d11933005-Reviews-Sexy_Mamma_Love_Spaghetti-Nottingham_Nottinghamshire_England.html" target="_blank">Sexy Mama's Spaghetti</a></li>
             <li><a href="http://bonzai-japaneserestaurant.co.uk/" target="_blank">Bonzai</a></li>
 
-            <h4>Extra Requirements?</h4>
-            <p>
+            <h4 tabIndex="0">Extra Requirements?</h4>
+            <p tabIndex="0">
                 If you need to know about any vegan, vegetarian or gluten-free restaurants, get in touch and we will point
                 you in the direction of some great ones. 
             </p>

--- a/pages/about/sponsor-information.js
+++ b/pages/about/sponsor-information.js
@@ -12,13 +12,13 @@ export default () => (
         <Header title={'Sponsor Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
             
             <p><strong><a href="#sponsor-brief">Sponsor Brief</a></strong></p>
 
             <p><strong><a href="#code-of-conduct">Code of Conduct</a></strong></p>
 
-            <p><strong>Before The Conference</strong></p>
+            <p tabIndex="0"><strong>Before The Conference</strong></p>
             <ul>
                 <li><a href="#tickets">Tickets</a></li>
                 <li><a href="#items">Attendee Bag Items</a></li>
@@ -26,26 +26,26 @@ export default () => (
                 <li><a href="#gold-sponsors">Gold Representatives</a></li>
             </ul>
 
-            <p><strong>Setup The Day Before Conference</strong></p>
+            <p tabIndex="0"><strong>Setup The Day Before Conference</strong></p>
             <ul>
                 <li><a href="#setup-time">Time To Setup</a></li>
                 <li><a href="#before-parking">Parking</a></li>
                 <li><a href="#lift-restrictions">Lift Restrictions</a></li>
             </ul>
 
-            <p><strong>Transport On The Day</strong></p>
+            <p tabIndex="0"><strong>Transport On The Day</strong></p>
             <ul>
                 <li><a href="#train">Taking the train</a></li>
                 <li><a href="#driving">Driving</a></li>
             </ul>
 
-            <p><strong>Setup On The Day</strong></p>
+            <p tabIndex="0"><strong>Setup On The Day</strong></p>
             <ul>
                 <li><a href="#arrival">Arrival</a></li>
                 <li><a href="#signing-in">Signing In</a></li>
             </ul>
 
-            <p><strong>General Conference Day Information</strong></p>
+            <p tabIndex="0"><strong>General Conference Day Information</strong></p>
             <ul>
                 <li><a href="#power">Power</a></li>
                 <li><a href="#exhibition-staff">Exhibition Stall Staff</a></li>
@@ -54,26 +54,26 @@ export default () => (
                 <li><a href="#catering">Catering</a></li>
             </ul>
 
-            <p><strong>Exhibition Stalls</strong></p>
+            <p tabIndex="0"><strong>Exhibition Stalls</strong></p>
             <ul>
                 <li><a href="#provided">What Is Provided?</a></li>
                 <li><a href="#provide">What To Bring</a></li>
                 <li><a href="#booth-restrictions">Restrictions</a></li>
             </ul>
 
-            <p><strong>Social Media and Photos</strong></p>
+            <p tabIndex="0"><strong>Social Media and Photos</strong></p>
             <ul>
                 <li><a href="#photographs">Photographs</a></li>
                 <li><a href="#instagram">Instagram Stories</a></li>
                 <li><a href="#social-posts">Social Media Posts</a></li>
             </ul>
 
-            <p><strong>Packing Up Day Of The Conference</strong></p>
+            <p tabIndex="0"><strong>Packing Up Day Of The Conference</strong></p>
             <ul>
                 <li><a href="#teardown-time">Pick Up Time</a></li>
             </ul>
 
-            <p><strong>PubConf - The Unofficial After Party</strong></p>
+            <p tabIndex="0"><strong>PubConf - The Unofficial After Party</strong></p>
             <ul>
                 <li><a href="#after-party-about">About</a></li>
                 <li><a href="#after-party-rules">Rules of PubConf</a></li>
@@ -85,109 +85,109 @@ export default () => (
         </section>
         
         <section id="sponsor-brief">
-        <h1>Sponsor Brief</h1> 
+        <h1 tabIndex="0">Sponsor Brief</h1> 
             <a name="sponsor-brief"/>
-            <h2>Thank you.</h2>
-            <p>
+            <h2 tabIndex="0">Thank you.</h2>
+            <p tabIndex="0">
                 Without your support, there wouldn’t be a DDD East Midlands event at all. This page outlines what you need to know on the day. 
             </p>
-            <p>
+            <p tabIndex="0">
                 This year we expect around 350 - 400 attendees to join us for a day of learning and networking for the East Midlands technology community. 
             </p>
         </section>     
 
         <section id="code-of-conduct">
-        <h1>Code of Conduct</h1> 
+        <h1 tabIndex="0">Code of Conduct</h1> 
             <a name="code-of-conduct"/>
-            <h2>Please familiarise yourself with the Code of Conduct.</h2>
-            <p>
+            <h2 tabIndex="0">Please familiarise yourself with the Code of Conduct.</h2>
+            <p tabIndex="0">
                All involved in the DDD East Midlands Conference are subject to <a href="https://www.dddeastmidlands.com/code-of-conduct/">Code Of Conduct Page.</a> 
                This is not just for the day of the event, but for all presence of DDD East Midlands including Social Media.
             </p>
-            <p>
+            <p tabIndex="0">
                 Please make sure you are familiar with it and adhere to it at all times to create the most inclusive and friendly event for all involved.
             </p>
-            <p>
+            <p tabIndex="0">
                 Should you have any concerns regarding the Code of Conduct before, during or after the event, please contact the organisers. See the <a href="/contact" target="_blank">contact page for information.</a>
             </p>
         </section> 
 
         <section id="before-the-conference">
-        <h1>Before The Conference</h1> 
+        <h1 tabIndex="0">Before The Conference</h1> 
             <a name="tickets"/>
-            <h2>Tickets</h2>
-            <p>
+            <h2 tabIndex="0">Tickets</h2>
+            <p tabIndex="0">
                 If you have supported at Gold, Silver, Bronze or Standard Tier, you will have been allotted some tickets to the conference.
             </p>
-            <p>
+            <p tabIndex="0"> 
                 If you know who your guaranteed tickets are going to be given to, please provide us with their emails so that we can send a link to Eventbrite. If this is still unsure, we can provide a code for you to access tickets with.
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong>If you have told us who to send your tickets to:</strong>
             </p>
             <ul>
-                <li>If you have an exhibition booth, please ensure that your booth will be covered by 1 - 3 of your ticket holders.</li>
-                <li>Please make sure the people assigned can still make it on the day.</li>
+                <li tabIndex="0">If you have an exhibition booth, please ensure that your booth will be covered by 1 - 3 of your ticket holders.</li>
+                <li tabIndex="0">Please make sure the people assigned can still make it on the day.</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 <strong>If you haven't told us who to assign your tickets too:</strong>
             </p>
             <ul>
-                <li>                
+                <li tabIndex="0">                
                     If you have an exhibition booth we suggest that 1 - 3 of your tickets are given to those managing your exhibition booth.
                 </li>
-                <li>
+                <li tabIndex="0">
                     If you don't have an exhibition booth or have tickets spare, you can:
                     <ul>
-                        <li> 
+                        <li tabIndex="0"> 
                             Give tickets out internally so your employees can benefit from the day.
                         </li> 
-                        <li>
+                        <li tabIndex="0">
                             Donate a ticket to local meetup.
                         </li>
-                        <li>
+                        <li tabIndex="0">
                             Give a tickeet away in a competition.
                         </li> 
                     </ul>
                 </li>
             </ul>
-            <p>Whatever you think is best.</p>
-            <p>
+            <p tabIndex="0">Whatever you think is best.</p>
+            <p tabIndex="0">
                 <strong>Assigning Tickets:</strong>
             </p>
-            <p>
+            <p tabIndex="0">
                 Contact <a href="mailto:jessica@dddeastmidlands.com">Jessica </a>with the email addresses and name of your recepients. She will send an Eventbrite invite to that email address.
             </p>
-            <p>
+            <p tabIndex="0">
                 Any tickets you consider “extra” as part of your sponsorship, you can dispense as you wish. Contact Jessica if you want assistance with this.
             </p>
 
             <a name="items"/>
-            <h2>Attendee Bag Items</h2>
-            <p>
+            <h2 tabIndex="0">Attendee Bag Items</h2>
+            <p tabIndex="0">
                 Gold and Silver Tier Sponsors can provide items and inserts for attendee bags. These bags will be given to all attendee's on the day of the conference.
                 You can provide swag and/or printed media (company adverts, job adverts etc.).
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong>Attendee bag items should be provided at least one week before the conference.</strong> This is so we can prepare the bags before the conference.
                 Please make arrangements with Jessica for drop off or collection.
             </p>
 
             <a name="pat-before"/>
-            <h2>PAT Testing</h2>
-            <h4>If you can, get any devices that will be plugged in PAT tested before the event.</h4>
-            <p>            
+            <h2 tabIndex="0">PAT Testing</h2>
+            <h4 tabIndex="0">If you can, get any devices that will be plugged in PAT tested before the event.</h4>
+            <p tabIndex="0">            
                 Due to venue insurance restrictions, we need to be sure that anything that may be plugged 
                 into a socket on the day <strong>either:</strong>
             </p>
             <ul>
-                <li>Has a current PAT test sticker/certificate</li>
-                <li>Is less than one year old. Please ensure that where electrical items are less than a year old, evidence of this is provided.</li>
+                <li tabIndex="0">Has a current PAT test sticker/certificate</li>
+                <li tabIndex="0">Is less than one year old. Please ensure that where electrical items are less than a year old, evidence of this is provided.</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 This includes any laptop chargers or phone chargers.
             </p>
-            <p>
+            <p tabIndex="0">
                 We will provide limited PAT testing on the day, with speakers being priority candidates for this service.
                 This service will be available between <strong>7.30am - 9.30am the day of the conference</strong>. Registration for the 
                 event opens to the general public at 8.00am so there is a window in the morning where exclusively speakers and exhibitors can 
@@ -195,70 +195,70 @@ export default () => (
             </p>
 
             <a name="gold-sponsors"/>
-            <h2>Gold Representatives</h2>
-            <p>
+            <h2 tabIndex="0">Gold Representatives</h2>
+            <p tabIndex="0">
                This section only concerns our Gold Tier Sponsors. 
             </p>
-            <p>
+            <p tabIndex="0">
                We will need some information from you before the event. As part of your sponsorship offering, we will say a short bit about your company but also 
                present the details of a representative that can be approached at the conference. We will need the following:
             </p>
             <ul>
-                <li>A short brief about your company to be given at the opening presentation. A couple of paragraphs long.</li>
-                <li>The name of your represenative for the day.</li>
-                <li>The job title of your represenative for the day.</li>
-                <li>A photo of your represenative for the day.</li>
-                <li>Contact details that your represenative might want to share.</li>
+                <li tabIndex="0">A short brief about your company to be given at the opening presentation. A couple of paragraphs long.</li>
+                <li tabIndex="0">The name of your represenative for the day.</li>
+                <li tabIndex="0">The job title of your represenative for the day.</li>
+                <li tabIndex="0">A photo of your represenative for the day.</li>
+                <li tabIndex="0">Contact details that your represenative might want to share.</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 These will be presented alongside your logo in the opening ceremony.
             </p>
         </section> 
 
         <section id="day-before">
-        <h1>Setup The Day Before Conference</h1> 
+        <h1 tabIndex="0">Setup The Day Before Conference</h1> 
     
             <a name="setup-time"/>
-            <h2>Time To Setup</h2>
-            <p>
+            <h2 tabIndex="0">Time To Setup</h2>
+            <p tabIndex="0">
                 You will be emailed a time slot closer to the event, in which you can set up your exhibition stall. This time slot will be somewhere between 18.00 – 21.30 on the 25th of October (the night before the event).
             </p>
-            <p>
+            <p tabIndex="0">
                 We have to arrange this into time slots due to the limited vehicle space at the venue. If there are any restrictions you have regarding time slot, please let us know in advance.
             </p>
-            <p>
+            <p tabIndex="0">
                 On the day of the event, the organisers will be at the venue from 07.15. You may turn up any time from then. Attendee registration opens at 8.00am.
             </p>
             
             <a name="before-parking"/>
-            <h2>Parking</h2>
-            <p>
+            <h2 tabIndex="0">Parking</h2>
+            <p tabIndex="0">
                 Please use the loading bay on South Sherwood Street during your allotted time.
             </p>
-            <p>
+            <p tabIndex="0">
                 The entrance to the South Sherwood Street loading bay on a busy road and right next to a bus stop. We ask that you do not obstruct this entrance, but instead, only park within the loading bay.
             </p>
-            <p>
+            <p tabIndex="0">
                 Please limit yourselves to using one vehicle at a time.  
             </p>
 
             <a name="lift-restrictions"/>
-            <h2>Lift Restrictions</h2>
-            <p>
+            <h2 tabIndex="0">Lift Restrictions</h2>
+            <p tabIndex="0">
                 Below are the lift restrictions. Please keep these in mind for anything you are bringing for your exhibition stall.
             </p>
             <table>
-              <tr>
+              <tr tabIndex="0">
                 <th>Lift</th>
                 <th>Dimensions</th>
                 <th>Max Weight.</th>
               </tr>
-              <tr>
+              <tr tabIndex="0">
                 <td>Loading bay lift</td>
                 <td>Open topped x 1000 mm x 1470 mm</td>
                 <td>1000 kg</td>
               </tr>
-              <tr>
+              <tr tabIndex="0">
                 <td>Newton lift doors</td>
                 <td>2100 mm x 1100 mm</td>
                 <td>1000 kg</td>
@@ -268,11 +268,11 @@ export default () => (
         </section> 
 
         <section id="transport">
-        <h1>Transport On The Day</h1>            
+        <h1 tabIndex="0">Transport On The Day</h1>            
             <a name="train"/>
-            <h2>Taking the train</h2>
-            <h4>Head to Nottingham Train Station</h4>
-            <p>
+            <h2 tabIndex="0">Taking the train</h2>
+            <h4 tabIndex="0">Head to Nottingham Train Station</h4>
+            <p tabIndex="0">
                 Nottingham Station is the mainline train station close to Nottingham city centre. The train station is a
                 15 minute walk from Nottingham Conference Centre, but for those new to the city it might be easier to
                 take a taxi or use Nottingham’s tram NET (Nottingham Express Transit) system. Directions to the station
@@ -283,65 +283,65 @@ export default () => (
             </p>
             
             <a name="driving"/>
-            <h2>Driving</h2>
-            <h4>Directions to Park and Rides</h4>
-            <p>
+            <h2 tabIndex="0">Driving</h2>
+            <h4 tabIndex="0">Directions to Park and Rides</h4>
+            <p tabIndex="0">
                 From the north, exit the M1 at junction 26 and follow the signs for the A610 towards Nottingham city
                 centre.
             </p>
-            <p>
+            <p tabIndex="0">
                 There is a Park and Ride (tram) facility situated close to the M1 junction 26. The Park and Ride
                 (Phoenix Park) site is clearly sign-posted off the A610. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Leave the tram at the Nottingham Trent University tram stop which is located on Goldsmith Street and walk past the main University entrance,
                 turn left on to Burton Street where you will find the Nottingham Conference Centre entrance. 
             </p>
-            <p>
+            <p tabIndex="0">
                 From the south, exit the M1 at junction 24 and follow the signs for the A453 to Nottingham city centre. 
             </p>
-            <p>
+            <p tabIndex="0">
                 The Queen’s Drive Park and Ride is located just off the A453 (Queen’s Drive), follow signs for A453 /
                 Queen’s Drive Industrial Estate and merge on to the A453 (Queen’s Drive). The Park and Ride is located
                 on the opposite side of the road to the retail park and is clearly sign-posted. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Alight from the Park and Ride bus on Lower Parliament Street (Victoria Centre); Nottingham Conference Centre is a short walk
                 away.
             </p>
             
-            <h4>Car parks</h4>
-            <p>
+            <h4 tabIndex="0">Car parks</h4>
+            <p tabIndex="0">
                 Car parks in the city centre are clearly signposted from all major approach routes. There are two car
                 parks close to Nottingham Conference Centre, Trinity Square car park on North Church Street and Talbot
                 Street car park. For satellite navigation systems please use the following information:
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="http://www.nottinghamcity.gov.uk/transport-parking-and-streets/parking-and-permits/city-centre-parking/car-parks/trinity-square-car-park/" target="_blank">Trinity Square car park:</a></strong> postcode NG1 4BR<br />
                 co-ordinates 52.956785,-1.149316
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="https://www.q-park.co.uk/en-gb/cities/nottingham/talbot-street/" target="_blank">Talbot Street car park:</a></strong> postcode NG1 5GG<br />
                 co-ordinates 52.956143,-1.154433
             </p>
         </section>
 
         <section id="setup-on-day">
-        <h1>Setup On The Day</h1> 
+        <h1 tabIndex="0">Setup On The Day</h1> 
         
             <a name="arrival"/>
-            <h2>Arrival</h2>
-            <p>
+            <h2 tabIndex="0">Arrival</h2>
+            <p tabIndex="0">
                 You can arrive at the venue any time after 7.15am on the day of the event. This will give you the opportunity to do 
                 any last minute set up and settle in before registration opens at 8.00am. 
             </p>
-            <p>
+            <p tabIndex="0">
                 If you need to use the PAT testing service we are providing, that opens from 7.30am. 
             </p>
 
             <a name="signing-in"/>
-            <h2>Signing In</h2>
-            <p>
+            <h2 tabIndex="0">Signing In</h2>
+            <p tabIndex="0">
                 All those who are looking after your exhibition booth that have a ticket through your sponsorship will have an Eventbrite ticket. On coming in, 
                 a crew member will scan the QR code on your Eventbrite ticket. You will then be directed to fill in your lanyards.
             </p>
@@ -349,106 +349,106 @@ export default () => (
         </section>
 
         <section id="general">
-        <h1>General Conference Day Information</h1> 
+        <h1 tabIndex="0">General Conference Day Information</h1> 
             <a name="power"/>
-            <h2>Power</h2>
-            <p>
+            <h2 tabIndex="0">Power</h2>
+            <p tabIndex="0">
                 There will be some electricity sockets available on the day. DDD East Midlands will provide extension cables on request if you will need multiple ports on the day. 
                 Please contact Jessica: <a href="mailto:jessica@dddeastmidlands.com">jessica@dddeastmidlands.com</a> at least two weeks prior to the event.                 
             </p>
-            <p>
+            <p tabIndex="0">
                 Due to the venues insurance policy we require that any plugged in devices are PAT tested and have an in date sticker.
             </p>
-            <p>
+            <p tabIndex="0">
                 We can provide PAT testing for a limited number of devices on the day, but priority will be given to speakers for the available slots. Where possible 
                 please have your devices that will be plugged in on the day PAT tested.
             </p>
 
             <a name="exhibition-staff"/>
-            <h2>Exhibition Stall Staff</h2>
-            <p>
+            <h2 tabIndex="0">Exhibition Stall Staff</h2>
+            <p tabIndex="0">
                 We expect that you have 1-3 people working at the exhibition stall. These are included in your ticket allowance for the event.
                 Please have these people register their ticket at check-in on the day.
             </p>
-            <p>
+            <p tabIndex="0">
                 Exhibitions stalls can be visited throughout the whole day, including during talk sessions. We expect you will be most busy during the breaks.
             </p>
 
             <a name="health-and-safety"/>
-            <h2>Health and Safety</h2>
-            <p>
+            <h2 tabIndex="0">Health and Safety</h2>
+            <p tabIndex="0">
                 There will be space behind exhibition stall partitions for storage. Passageways, stairways and fire exits shall be kept free of obstruction; all loose packaging must be removed to keep walkways free from tripping hazards.
             </p>
-            <p>
+            <p tabIndex="0">
                 Exhibitors exhibit entirely at their own risk. Nottingham Conference Centre and DDD East Midlands are not liable for any losses or damage to property which may occur.
             </p>
-            <p>
+            <p tabIndex="0">
                 In the opening ceremony, there will be a briefing about fire evacuation procedures. If you are unable to attend the opening ceremony please request this information from either Moreton or Jessica.
             </p>
 
             <a name="wifi"/>
-            <h2>Wifi</h2>
-            <p>
+            <h2 tabIndex="0">Wifi</h2>
+            <p tabIndex="0">
                 Free Wi-Fi is supplied by the venue. There will be separate access codes provided for staff/exhibitors and attendees. Access details are provided on the day. 
             </p>
 
             <a name="catering"/>
-            <h2>Catering</h2>
-            <p>
+            <h2 tabIndex="0">Catering</h2>
+            <p tabIndex="0">
                 Lunch and snacks will be provided on the day.
             </p>
-            <p>
+            <p tabIndex="0">
                 All food is prepared in kitchens where nuts, gluten and other allergens could be present. As the menu descriptions cannot include all ingredients, please let us know prior to arrival if any of your representatives have a food allergy, and we will try to cater to them.
             </p>
         </section>
 
         <section id="stalls">
-        <h1>Exhibition Stalls</h1> 
+        <h1 tabIndex="0">Exhibition Stalls</h1> 
             <a name="provided"/>
-            <h2>What Is Provided?</h2>
+            <h2 tabIndex="0">What Is Provided?</h2>
             <ul>
-                <li>Provided table size: 170 cm x 150 cm</li>
-                <li>Grey background screens.</li>
+                <li tabIndex="0">Provided table size: 170 cm x 150 cm</li>
+                <li tabIndex="0">Grey background screens.</li>
             </ul>
 
             <a name="provide"/>
-            <h2>What Is Recommended To Bring?</h2>
+            <h2 tabIndex="0">What Is Recommended To Bring?</h2>
             <ul>
-                <li>Linen</li>
-                <li>Anything for decorating your exhibition stall and background screens (swag, banners, leaflets, promotional material).</li>
-                <li><i>(If included in your sponsorship)</i> Banners away from your exhibition booth</li>
+                <li tabIndex="0">Linen</li>
+                <li tabIndex="0">Anything for decorating your exhibition stall and background screens (swag, banners, leaflets, promotional material).</li>
+                <li tabIndex="0"><i>(If included in your sponsorship)</i> Banners away from your exhibition booth</li>
             </ul>
 
             <a name="booth-restrictions"/>
-            <h2>Restrictions</h2>
+            <h2 tabIndex="0">Restrictions</h2>
             <ul>
-                <li>Please avoid bringing any displays with automatically moving parts, unless you can be assured that they will not be left unattended</li>
-                <li>The height/weight restrictions of the lifts.</li>
+                <li tabIndex="0">Please avoid bringing any displays with automatically moving parts, unless you can be assured that they will not be left unattended</li>
+                <li tabIndex="0">The height/weight restrictions of the lifts.</li>
             </ul>
 
         </section> 
 
         <section id="social-media">
-        <h1>Social Media and Photos</h1>
-            <p>
+        <h1 tabIndex="0">Social Media and Photos</h1>
+            <p tabIndex="0">
                 Feel free to take photos and post on social media before, after and during the event. There are just a few guidelines we ask you to respect.
             </p> 
             <a name="photographs"/>
-            <h2>Photographs</h2>
-            <p>
+            <h2 tabIndex="0">Photographs</h2>
+            <p tabIndex="0">
                 We will have a coloured lanyard system at the event to indicate whether attendees are OK with their photo being taken and used.
             </p>
             <ul>
-                <li className="green">Green — It’s fine for their photo to be taken</li>
-                <li className="red">Red — Do not include me in your photos or promotional material</li>
+                <li tabIndex="0" className="green">Green — It’s fine for their photo to be taken</li>
+                <li tabIndex="0" className="red">Red — Do not include me in your photos or promotional material</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 We ask that you please respect this system and only use photos that have attendees with green lanyards only.
             </p>
 
             <a name="instagram"/>
-            <h2>Instagram Stories</h2>
-            <p>
+            <h2 tabIndex="0">Instagram Stories</h2>
+            <p tabIndex="0">
                 As part of the first event, we are going to have some select volunteers run a couple of our social media accounts. 
                 If you would not mind appearing on our Instagram stories with a short video of what you have thought about the event 
                 and your experience of taking part, please let us know so our helpful volunteers can come to your exhibition booth to record 
@@ -456,92 +456,92 @@ export default () => (
             </p>
 
             <a name="social-media"/>
-            <h2>Social Media Posts</h2>
-            <p>
+            <h2 tabIndex="0">Social Media Posts</h2>
+            <p tabIndex="0">
                 Please use any of the below information to tag us. If using our hashtag or handles though, please avoid promoting 
                 anything that doesn’t align with our code of conduct, or advertising job roles (unless allowed as part of your sponsorship agreement).
             </p>
-            <h3>DDD East Midlands on Social Media</h3>
-            <ul>Hashtags:   #DDDEM   |    #DDDEM2019</ul>
-            <ul>Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
-            <ul>LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
-            <ul>Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
+            <h3 tabIndex="0">DDD East Midlands on Social Media</h3>
+            <ul tabIndex="0">Hashtags:   #DDDEM   |    #DDDEM2019</ul>
+            <ul tabIndex="0">Twitter: <a href="https://twitter.com/dddeastmidlands" target="_blank">@dddeastmidlands</a></ul>
+            <ul tabIndex="0">LinkedIn: <a href="https://www.linkedin.com/company/ddd-east-midlands-limited/" target="_blank">DDD East Midlands Limited</a></ul>
+            <ul tabIndex="0">Instagram: <a href="https://www.instagram.com/dddeastmidlands/?hl=en" target="_blank">@dddeastmidlands</a></ul>
         </section> 
 
         <section id="packing-up">
-        <h1>Packing Up Day Of The Conference</h1> 
+        <h1 tabIndex="0">Packing Up Day Of The Conference</h1> 
             <a name="teardown-time"/>
-            <h2>Collecting your exhibition items.</h2>
-            <p>
+            <h2 tabIndex="0">Collecting your exhibition items.</h2>
+            <p tabIndex="0"> 
                 You will be emailed a time slot closer to the event, in which you can bring a vehicle to the venue to collect any remaining items from your exhibition stall.  
                 This time slot will be somewhere between 16.30 – 18.30 on the 26th of October (the day of the event).
             </p>
-            <p>
+            <p tabIndex="0">
                 We have to arrange this into time slots due to the limited vehicle space at the venue. If there are any restrictions you have regarding time slot, 
                 or you don’t think you will need one, please let us know in advance.
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong>Location: </strong>We ask that you use the loading bay on South Sherwood Street.
             </p>
         </section>
 
         <section id="pubconf">
-        <h1>PubConf - The Unofficial After Party</h1> 
+        <h1 tabIndex="0">PubConf - The Unofficial After Party</h1> 
 
             <a name="after-party-about"/>
-            <h2>About</h2>
-            <p>
+            <h2 tabIndex="0">About</h2>
+            <p tabIndex="0">
                 After the conference, there will be a special <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf</a> featuring some of our speakers and special guests. This 
                 evening event has comedy talks, music, food and beverages. It's great fun for all and we encourage you to come along.
             </p>
             <p>
-                <strong>Quick about:</strong>
+                <h4 tabIndex="0">Quick about:</h4>
                 <ul>
-                    <li>
+                    <li tabIndex="0">
                         The talks conducted at PubConf are 5 minute, comedy ignite talks:
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         20 slides timed to increment every 15 seconds. The speakers have no control
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         The top three talks will go into a final battle to win prizes. These three finalists will be presented 
                         with a ignite deck they have never seen before and given a topic. They will then have to come up with an 
                         impromptu talk on the spot.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         Talk topics have an emphasis on humour. Often the content is not suitable to be shared away 
                         from the safety of PubConf.
                     </li>
-                    <li>
+                    <li tabIndex="0">
                         PubConf is a separate entity and business from DDD East Midlands. As such they have their own 
                         Code of Conduct. Hence "Unofficial" after party. We are not involved in its organisation.
                     </li>
                 </ul>
             </p>
-            <p>
+            <p tabIndex="0">
                 This is the first PubConf in the UK outside of London and it's going to be brilliant.
             </p>
             
             <FullWidthImage url={'/static/banners/pubconf.png'}/>
 
             <a name="after-party-rules"/>
-            <h2>Rules of PubConf</h2>
+            <h2 tabIndex="0">Rules of PubConf</h2>
             <p>
-                <strong>What happens at PubConf, stays at Pubconf.</strong>
+                <h4 tabIndex="0">What happens at PubConf, stays at Pubconf.</h4>
                 <ul>
-                    <li>No photos or videos unless you have the speakers explicit permission.</li>
-                    <li>No quoting talks. (Taken out of context, a joke can be damaging)</li>
+                    <li tabIndex="0">No photos or videos unless you have the speakers explicit permission.</li>
+                    <li tabIndex="0">No quoting talks. (Taken out of context, a joke can be damaging)</li>
                 </ul>
                 <strong>Age limit is over 18 years old as the venue is serving alcohol.</strong>
             </p>
 
             <a name="pubconf-tickets"/>
-            <h2>Be alerted about tickets</h2>
-            <p>
+            <h2 tabIndex="0">Be alerted about tickets</h2>
+            <p tabIndex="0">
                 Go to the <a href="https://pubconf.io/events/2019/nottingham/" target="_blank">PubConf website</a> to find out more and 
                 sign up for an email alert when tickets are released.
             </p>
-            <p>
+            <p tabIndex="0">
                 Anyone can attend PubConf. They don't need to have gone to the DDD East Midlands Conference.
             </p>
         </section>
@@ -549,16 +549,16 @@ export default () => (
 
         <section id="contact">
         <a name="contact"/>
-        <h1>Contact</h1> 
-            <p>
+        <h1 tabIndex="0">Contact</h1> 
+            <p tabIndex="0">
                 There are a number of ways to contact the organisers before and during the event:
             </p>
-            <h2>Slack</h2>
-            <p>
+            <h2 tabIndex="0">Slack</h2>
+            <p tabIndex="0">
                 You will be added to a DDD East Midlands Slack Channel. Jessica and Moreton will be reachable on there. Please use their handle for anything urgent.
             </p>
-            <h2>Email</h2>
-            <p>
+            <h2 tabIndex="0">Email</h2>
+            <p tabIndex="0">
                 Using the @dddeastmidlands.com email addresses:
                 <li><a href="mailto:jessica@dddeastmidlands.com">Jessica's email</a></li>
                 <li><a href="mailto:moreton@dddeastmidlands.com">Moreton's email</a></li>

--- a/pages/about/ticket-information.js
+++ b/pages/about/ticket-information.js
@@ -11,7 +11,7 @@ export default () => (
         <Header title={'Ticket Information'}/>
 
         <section name="Contents">
-            <h1>Contents</h1>
+            <h1 tabIndex="0">Contents</h1>
 
             <p><strong><a href="#ticketcost">How much do tickets cost?</a></strong></p>
             <p><strong><a href="#ticketrelease">When will tickets be released?</a></strong></p>
@@ -22,42 +22,42 @@ export default () => (
 
         <section id="cost">
             <a name="ticketcost"/>
-            <h1>How much do tickets cost?</h1>
-            <p>
+            <h1 tabIndex="0">How much do tickets cost?</h1>
+            <p tabIndex="0">
                Tickets for the event will be free but limited in availability. We wanted to ensure that price wouldn't be a barrier for those wanting to attend.
             </p>
         </section>
 
         <section>
             <a name="ticketrelease"/>
-            <h1>When will tickets be released?</h1>
-            <p>
+            <h1 tabIndex="0">When will tickets be released?</h1>
+            <p tabIndex="0">
                 Tickets have already been released for the 2019 event.
             </p>
         </section>
 
         <section>
             <a name="soldout"/>
-            <h1>What if tickets are sold out?</h1>
-            <p>
+            <h1 tabIndex="0">What if tickets are sold out?</h1>
+            <p tabIndex="0">
                 You can sign up to the waitlist through <a href="https://www.eventbrite.co.uk/e/ddd-east-midlands-tickets-58629047058" target="_blank">registering on Eventbrite.</a>
             </p>
-            <p>
+            <p tabIndex="0">
                 If you are signed up to the waitlist, this means when a ticket becomes available and you are next on the list, you will be emailed and given 24 hours to claim the ticket.
             </p>
         </section>
 
         <section>
             <a name="return"/>
-            <h1>What do if I can't come to the event anymore?</h1>
-            <p>
+            <h1 tabIndex="0">What do if I can't come to the event anymore?</h1>
+            <p tabIndex="0">
                 If you can no longer come to the event you (we are sad you can't make it!) please return your ticket so that someone else can claim it.
             </p>
-            <p>
+            <p tabIndex="0">
                 You can return your ticket through a couple of ways:    
             </p>
             <ul>
-                <li>Return it through Eventbrite.</li>
+                <li tabIndex="0">Return it through Eventbrite.</li>
                 <li><a href="contact" target="_blank">Contact Jessica and she can sort it out for you.</a></li>
             </ul>
         </section>

--- a/pages/about/venue.js
+++ b/pages/about/venue.js
@@ -86,9 +86,9 @@ export default (props) => (
         </section>
 
         <section>
-            <h3 tabIndex="0">
+            <h4 tabIndex="0">
                 Car parking
-            </h3>
+            </h4>
             <p tabIndex="0">
                 Car parks in the city centre are clearly signposted from all major approach routes. There are two car
                 parks close to Nottingham Conference Centre, Trinity Square car park on North Church Street and Talbot

--- a/pages/about/venue.js
+++ b/pages/about/venue.js
@@ -13,7 +13,7 @@ export default (props) => (
         <Header title={'Venue'}/>
 
         <section>
-            <h2 className="aligncenter">
+            <h2 tabIndex="0" className="aligncenter">
                 We are super excited to announce that we will be hosted by 
                 <br/>
                 <a href="http://www.nottinghamconferencecentre.co.uk/">The Nottingham Conference Centre</a>.
@@ -23,16 +23,16 @@ export default (props) => (
             <FullWidthImage url={'/static/banners/thencc.jpg'}/>
         </section>
         <section>
-            <h1>
+            <h1 tabIndex="0">
                 Directions to Nottingham Conference Centre
             </h1>
         </section>
         <VenueButton/>
         <section>
-            <h2>
+            <h2 tabIndex="0">
                 By rail
             </h2>
-            <p>
+            <p tabIndex="0">
                 Nottingham Station is the mainline train station close to Nottingham city centre. The train station is a
                 15 minute walk from Nottingham Conference Centre, but for those new to the city it might be easier to
                 take a taxi or use Nottingham’s tram NET (Nottingham Express Transit) system. Directions to the station
@@ -44,10 +44,10 @@ export default (props) => (
         </section>
 
         <section>
-            <h2>
+            <h2 tabIndex="0">
                 By air
             </h2>
-            <p>
+            <p tabIndex="0">
                 The closest airport to Nottingham is East Midlands Airport which is 15 miles (approximately 24
                 kilometres) outside of the city. It takes about half an hour from there to travel into the city by car
                 or bus. There is a Skylink bus service that runs every half hour from the airport into Nottingham city
@@ -56,49 +56,49 @@ export default (props) => (
         </section>
 
         <section>
-            <h2>
+            <h2 tabIndex="0">
                 By car
             </h2>
-            <p>
+            <p tabIndex="0">
                 From the north, exit the M1 at junction 26 and follow the signs for the A610 towards Nottingham city
                 centre.
             </p>
-            <p>
+            <p tabIndex="0">
                 There is a Park and Ride (tram) facility situated close to the M1 junction 26. The Park and Ride
                 (Phoenix Park) site is clearly sign-posted off the A610. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Leave the tram at the Nottingham Trent University tram stop which is located on Goldsmith Street and walk past the main University entrance,
                 turn left on to Burton Street where you will find the Nottingham Conference Centre entrance. 
             </p>
-            <p>
+            <p tabIndex="0">
                 From the south, exit the M1 at junction 24 and follow the signs for the A453 to Nottingham city centre. 
             </p>
-            <p>
+            <p tabIndex="0">
                 The Queen’s Drive Park and Ride is located just off the A453 (Queen’s Drive), follow signs for A453 /
                 Queen’s Drive Industrial Estate and merge on to the A453 (Queen’s Drive). The Park and Ride is located
                 on the opposite side of the road to the retail park and is clearly sign-posted. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Alight from the Park and Ride bus on Lower Parliament Street (Victoria Centre); Nottingham Conference Centre is a short walk
                 away.
             </p>
         </section>
 
         <section>
-            <strong>
+            <h3 tabIndex="0">
                 Car parking
-            </strong>
-            <p>
+            </h3>
+            <p tabIndex="0">
                 Car parks in the city centre are clearly signposted from all major approach routes. There are two car
                 parks close to Nottingham Conference Centre, Trinity Square car park on North Church Street and Talbot
                 Street car park. For satellite navigation systems please use the following information:
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="http://www.nottinghamcity.gov.uk/transport-parking-and-streets/parking-and-permits/city-centre-parking/car-parks/trinity-square-car-park/" target="_blank">Trinity Square car park:</a></strong> postcode NG1 4BR<br />
                 co-ordinates 52.956785,-1.149316
             </p>
-            <p>
+            <p tabIndex="0">
                 <strong><a href="https://www.q-park.co.uk/en-gb/cities/nottingham/talbot-street/" target="_blank">Talbot Street car park:</a></strong> postcode NG1 5GG<br />
                 co-ordinates 52.956143,-1.154433
             </p>

--- a/pages/agenda.js
+++ b/pages/agenda.js
@@ -10,7 +10,7 @@ export default () => (
         </Head>
         <Header title={'Agenda'}/>
 
-        <section name="Agenda">
+        <section tabIndex="0" name="Agenda">
             <div className="sessionize-loader" data-sessionize-load-url="https://sessionize.com/api/v2/dwsqznmo/view/GridSmart?under=True"><div className="sz-spinner"></div></div>
         </section>
        

--- a/pages/code-of-conduct.js
+++ b/pages/code-of-conduct.js
@@ -11,8 +11,8 @@ export default () => (
         </Head>
         <Header title={'Code of Conduct'}/>
         <section>
-            <h2>TL;DR</h2>
-            <p>Treat everyone in a respectful and kind manner. Harassment and abuse are never tolerated. If you are in
+            <h2 tabIndex="0">TL;DR</h2>
+            <p tabIndex="0">Treat everyone in a respectful and kind manner. Harassment and abuse are never tolerated. If you are in
                 a situation that makes you uncomfortable at a DDD East Midlands event, if the event itself is creating
                 an unsafe or inappropriate environment or you are made to feel uncomfortable by anyone at any of our
                 events or in our online communities,             
@@ -20,50 +20,50 @@ export default () => (
             </p>
         </section>
         <section>
-            <h2>The Full Version</h2>
-            <p>
+            <h2 tabIndex="0">The Full Version</h2>
+            <p tabIndex="0">
                 Inclusivity is a core value of DDD East Midlands. We believe that every single person has the right to
                 take part in DDD East Midlands events and online communities in a safe and welcoming environment.
             </p>
-            <p>
+            <p tabIndex="0">
                 In order to avoid any situtations where an attendee may feel uncomfortable we ask that you not only treat others in
                 the manner that you would expect to be treated, but also to respect what makes other people feel comfortable. As part of 
                 this we ask that speakers and representatives of the event try to refrain from language or actions that may be considered 
                 offensive. This includes swearing. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Harassment includes but is not limited to offensive verbal or written comments related to gender,
                 age, sexual orientation, sexual behaviour, disability, physical appearance, body size, race, religion,
                 sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or
                 recording, sustained disruption of talks or other events, inappropriate physical contact, and
                 unwelcome sexual attention.
             </p>
-            <p>
+            <p tabIndex="0">
                 If what you’re doing is making someone feel uncomfortable, that counts as harassment and is enough
                 reason to stop doing it.
             </p>
-            <p>
+            <p tabIndex="0">
                 Participants asked to stop any harassing behaviour are expected to comply immediately. Sponsors,
                 venue staff, speakers, volunteers, organisers, and anyone else at any of our events or in our online
                 communities are also subject to the anti-harassment policy. In particular, attendees should not use
                 sexualised images, humour, activities, or other material in presentations, during events and on
                 our online community.
             </p>
-            <p>
+            <p tabIndex="0">
                 If a participant engages in harassing behaviour, DDD East Midlands may take any action DDD East
                 Midlands deems appropriate, including warning the offender or expulsion from the events and our
                 online communities with no eligibility for reimbursement or refund of any type.
             </p>
-            <p>
+            <p tabIndex="0">
                 If you are being harassed, notice that someone else is being harassed, or have any other concerns,
                 <a href="/contact" target="_blank"> please let a member of the event team know or contact and organiser</a>.
             </p>
-            <p>
+            <p tabIndex="0">
                 DDD East Midlands representatives will be happy to help participants contact venue security or
                 local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel
                 safe while involved in DDD East Midlands events and our online communities.
             </p>
-            <p>
+            <p tabIndex="0">
                 The facilities provided at DDD East Midlands events, including networks, internet access, wifi,
                 power supply, furniture, toilets and the physical environment in general, must be used with respect,
                 in full accordance of the law, the terms of this document and any additional terms laid out at the
@@ -73,36 +73,36 @@ export default () => (
             </p>
         </section>
         <section>
-            <h2>Reporting Code Of Conduct Violations</h2>
-            <p>
+            <h2 tabIndex="0">Reporting Code Of Conduct Violations</h2>
+            <p tabIndex="0">
                 If there is any circumstance where want to report a code of conduct violation, there are numerous people you 
                 can speak to at the event. 
             </p>
             <ul>
-                <li>
+                <li tabIndex="0">
                     The volunteers of the conference
                 </li>
-                <li>
+                <li tabIndex="0">
                     The conference organisers (Jessica / Moreton)
                 </li>
             </ul>
-            <p>
+            <p tabIndex="0"> 
                 Our volunteers are happy to listen to your concerns, though any concerns will ultimately 
                 be dealt with by the events organisers. All conversations around code of conduct violations will be dealt with 
                 sensitively and confidentially.
             </p>
-            <p>
+            <p tabIndex="0">
                 If you are uncomfortable speaking in person you can contact us on Twitter or by email, but there is 
                 no guaruntee that messages will be dealt with in a timely manner on the day.
             </p>
         </section>
         <section>
-            <h2>Approaching People About Jobs</h2>
-            <p>
+            <h2 tabIndex="0">Approaching People About Jobs</h2>
+            <p tabIndex="0">
                 At our events and on our online community it is not considered acceptable to approach people unsolicited
                 about jobs, it doesn't make for a welcoming environment and it isn't what our community is for.
             </p>
-            <p>
+            <p tabIndex="0"> 
                 Job promotions should include the name of the role, the name of the company and information about
                 where people can find out more and apply.
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,47 +18,47 @@ export default () => (
         <Header title={'DDD East Midlands'}/>
         
         <section>
-            <p>
+            <p tabIndex="0">
                 DDD East Midlands is an inclusive, not-for-profit technology conference that celebrates the unique tech,
                 talent and companies that the East Midlands has to offer. This event is run by community members to
                 promote collaboration and the amazing tech community that has already grown in the East Midlands.
             </p>
-            <p>
+            <p tabIndex="0">
                 This conference follows these DDD principles:
             </p>
             <ul>
-                <li>The event is hosted on a Saturday so that attendees do not have to take time from work.</li>
-                <li>Tickets to attend the event are free.</li>
-                <li>All talk submissions are anonymous.</li>
-                <li>There is a democratic selection process for talks involving attendees voting for what they want
+                <li tabIndex="0">The event is hosted on a Saturday so that attendees do not have to take time from work.</li>
+                <li tabIndex="0">Tickets to attend the event are free.</li>
+                <li tabIndex="0">All talk submissions are anonymous.</li>
+                <li tabIndex="0">There is a democratic selection process for talks involving attendees voting for what they want
                     to
                     see.
                 </li>
-                <li>The event is arranged with the community in mind.</li>
+                <li tabIndex="0">The event is arranged with the community in mind.</li>
             </ul>
-            <p>
+            <p tabIndex="0">
                 To find out more, see our About Page. If you are interested in sponsoring the event email
                 <a href="mailto:sponsor@dddeastmidlands.com">sponsor@dddeastmidlands.com</a>
             </p>
         </section>
 
         <section>
-            <h2>Important Dates</h2>
+            <h2 tabIndex="0">Important Dates</h2>
             <ImportantDatesList dates={ dates } />
         </section>
 
         <section>
-            <h2>Gold Sponsors</h2>
+            <h2 tabIndex="0">Gold Sponsors</h2>
             <TieredCompanies partners={gold}/>
         </section>
 
         <section>
-            <h2>Silver Sponsors</h2>
+            <h2 tabIndex="0">Silver Sponsors</h2>
             <TieredCompanies partners={silver}/>
         </section>
 
         <section>
-            <h2>Bronze Sponsors</h2>
+            <h2 tabIndex="0">Bronze Sponsors</h2>
             <TieredCompanies partners={bronze}/>    
         </section>
 

--- a/pages/speakers.js
+++ b/pages/speakers.js
@@ -12,30 +12,30 @@ export default () => (
         </Head>
         <Header title={'Speakers'}/>
         <section>
-            <h1>Keynote By Dylan Beattie
+            <h1 tabIndex="0">Keynote By Dylan Beattie
                 <Link target="_blank" href="https://twitter.com/dylanbeattie" onSelect={event => {
                     logEvent("twitter", "dylanbeattie")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h1>
-            <h2>The Art of Code</h2>
-            <p>
+            <h2 tabIndex="0">The Art of Code</h2>
+            <p tabIndex="0">
                 Software and technology has changed every aspect of the world we live in. At one extreme are the ‘mission critical’ applications - the code that runs our banks, our hospitals, our airports and phone networks. Then there’s the code we all use every day to browse the web, watch movies, create spreadsheets… not quite so critical, but still code that solves problems and delivers services. 
             </p>
-            <p>
+            <p tabIndex="0">
                 But what about the code that only exists because somebody wanted to write it? Code created just to make people smile, laugh, maybe even dance? Maybe even code that does nothing at all, created just to see if it was possible?
             </p>
-            <p>
+            <p tabIndex="0">
                 Join Dylan Beattie - programmer, musician, and creator of the Rockstar programming language - for an entertaining look at the art of code. We’ll look at the origins of programming as an art form, from Conway's Game of Life to the 1970s demoscene and the earliest Obfuscated C competitions. We’ll talk about esoteric languages and quines - how DO you create a program that prints its own source code? We’ll look at quine relays, code golf and generative art, and we’ll explore the phenomenon of live coding as performance - from the pioneers of electronic music to modern algoraves and live coding platforms like Sonic Pi. 
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Dylan_Beattie.png" alt="Smiley face" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Software Architect</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Software Architect</i></p>
+                    <p tabIndex="0">
                         Dylan wrote his first web page in 1992 and never looked back. He's been building data-driven web applications since the late 1990s, and has worked on everything from tiny standalone websites to complex distributed systems. He's the CTO at Skills Matter in London, he's a Microsoft MVP, and he's a regular speaker at conferences and user groups, where he's spoken about topics from continuous delivery and Conway's Law to the history of the web, federated authentication and hypermedia APIs. When he's not wrangling code, Dylan plays guitar and writes songs about code. He's online at <a target="_blank" href="https://www.dylanbeattie.net">www.dylanbeattie.net</a> and on Twitter as <a target="_blank" href="https://twitter.com/dylanbeattie">@dylanbeattie</a>.
                     </p>
                 </div>
@@ -43,29 +43,29 @@ export default () => (
         </section>
 
         <section name="matt-brunt">
-            <h2>Matt Brunt
+            <h2 tabIndex="0">Matt Brunt
                 <Link target="_blank" href="https://twitter.com/Brunty" onSelect={event => {
                     logEvent("twitter", "brunty")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Think like a hacker</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Think like a hacker</i></h3>
+            <p tabIndex="0">
                 Much in the same way that to secure a house it helps to know how to break in, knowing how to attack our systems will help us secure them. You have a lot of data in your organisations. Whether you think it's sensitive or not, it has value. Whether an attacker wants data for profit, a grudge, or just for fun we need to ensure that we don't just leave the door open for them to take what they want.            </p>
-            <p>
+            <p tabIndex="0">
                 In this session we'll start to think like a hacker. The what, why, who, where and how of an attacking mindset will leave you with practical steps you can take away and use to start protecting your systems a little better.            
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Matt_Brunt.png" alt="Smiley face" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Wizard</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Wizard</i></p>
+                    <p tabIndex="0">
                         Matt Brunt is a Developer with Helical Levity, a company educating and building the next generation of Cyber Security professionals.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         When not tinkering with code he can be found reading comics, fighting monsters in dungeons and dragons, or drinking tea and eating jaffa-cakes.
                     </p>
                 </div>
@@ -73,7 +73,7 @@ export default () => (
         </section> 
         
         <section name="jessica-salisbury">
-            <h2>Jessica Salisbury                
+            <h2 tabIndex="0">Jessica Salisbury                
                 <Link target="_blank" href="https://twitter.com/JessSalisburyy" onSelect={event => {
                     logEvent("twitter", "jesssalisbury")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -83,24 +83,24 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>The Power of the Feedback Loop</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>The Power of the Feedback Loop</i></h3>
+            <p tabIndex="0">
                 From how the body knows when to stop growing to saving lives from speeding cars, the feedback loop is a mechanism that secretly underlies every corner of our existence. The concept spans schools of thought in psychology, economics, biology and neuroscience and is now emerging in the intersection of technology and behavioural science. 
             </p>
-            <p>
+            <p tabIndex="0">
                 As technologists we are always looking to build products that are engaging and effective, and as people we strive to reach our full personal and working potential. Could the feedback loop be the piece we're all missing?
             </p>
-            <p>
+            <p tabIndex="0">
                 In this talk we'll dive into the structure of the feedback loop, some impressive examples of how powerful they can be and we'll explore how you can harness their power in your work and personal life.  
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Jessica_Salisbury.png" alt="Jessica Salisbury" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Behavioural Psychologist and Money Coaching Project Manager at Tully.</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Behavioural Psychologist and Money Coaching Project Manager at Tully.</i></p>
+                    <p tabIndex="0">
                         Jess is a Behavioural Psychologist and the Project Manager of Money Coaching at Tully, a business created to help people who are worried about money. Jess leads on Tully’s Money Coaching product which uses Open Banking data to engage consumers in positive financial decision making to improve their financial wellbeing. From helping those in debt manage their money to providing early intervention for those displaying detrimental patterns of behaviour, Jess is using her academic background in psychology to create highly personalised, data led Money Coaching that drives long term, financial behavioural change for Tully customers.                    
                     </p>
                 </div>
@@ -108,7 +108,7 @@ export default () => (
         </section> 
         
         <section name="anthony-dang">
-            <h2>Anthony Dang                
+            <h2 tabIndex="0">Anthony Dang                
                 <Link target="_blank" href="https://twitter.com/AnthonyDotNet" onSelect={event => {
                     logEvent("twitter", "anthonydang")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -118,24 +118,24 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Cache me outside - Caching Methodologies and Architectures</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Cache me outside - Caching Methodologies and Architectures</i></h3>
+            <p tabIndex="0">
                 Caching can be your best-friend or your worst best-friend. A poor cache implementation can mean the difference between experiencing blazing fast performance or unexplained random slowness, or both! It can even result in random stale (out of date) content which you can’t explain.
             </p>
-            <p>
+            <p tabIndex="0">
                 In this presentation we will demo and compare different caching methodologies, and their perceived real world uses. We will discuss Donut cache, Memory cache, Redis, Varnish, CDNs, and many more. We will dive into demos of real world implementations which can cause unpredictable problems. Some of these are horrible, and some are face-palm.
             </p>
-            <p>
+            <p tabIndex="0">
                 At the end of this presentation you will be aware of the different trade-offs with each caching methodology, and which might best for your situation.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Anthony_Dang.png" alt="Smiley face" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Head of Development</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Head of Development</i></p>
+                    <p tabIndex="0">
                         Anthony is the Technical Director at Radley Yeldar (London, UK). He writes tech articles, and is a regular presenter at conferences and meetups. He loves automation and development processes, experienced in scaling high performing teams across multiple countries, a Scrum certified Agile enthusiast, and a vocal proponent of Behaviour Driven Development. Originally from Sydney, Australia, he is now based in London.
                     </p>
                 </div>
@@ -143,7 +143,7 @@ export default () => (
         </section> 
         
         <section name="cara-holland">
-            <h2>Cara Holland
+            <h2 tabIndex="0">Cara Holland
                 <Link target="_blank" href="https://twitter.com/GraphicChange" onSelect={event => {
                     logEvent("twitter", "caraholland")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -153,27 +153,27 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Draw UX (or how to get your visual thinking groove on)</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Draw UX (or how to get your visual thinking groove on)</i></h3>
+            <p tabIndex="0">
                 Working visually is a super power. It increases your ability to understand and share complex information, think creatively and collaborate effectively. But for lots of adults drawing at work is a huge step outside of their comfort zone.
             </p>
-            <p>
+            <p tabIndex="0">
                 I'm a business visualiser who draws, writes and trains. 
             </p>
-            <p>
+            <p tabIndex="0">
                 In this session I will show you how to use visual skills throughout the UX journey, transforming your engagement and problem solving skills, and how you already have the functional drawing ability you need, even if you can barely draw a stick. Honest.
             </p>
-            <p>
+            <p tabIndex="0">
                 By the end of this session you will understand WHY working visually is so effective, but more importantly you'll get to see HOW it works by trying out visual exericises yourself.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Cara_Holland.png" alt="Cara Holland" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Founder and head doodler at Graphic Change</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Founder and head doodler at Graphic Change</i></p>
+                    <p tabIndex="0">
                         Founder, trainer and author of best selling book Draw a Better Business, Cara Holland has been working visually with companies as varied as Google and the NHS for the last 13 years. 
                         She also co-runs the Graphic Change Academy which has trained people in over 69 countries how to start drawing at work.                    
                     </p>
@@ -182,30 +182,30 @@ export default () => (
         </section> 
         
         <section name="mark-towndrow">
-            <h2>Mark Towndrow
+            <h2 tabIndex="0">Mark Towndrow
                 <Link target="_blank" href="https://twitter.com/mark_towndrow" onSelect={event => {
                     logEvent("twitter", "marktowndrow")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>How to be a better developer - without learning another JavaScript framework</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>How to be a better developer - without learning another JavaScript framework</i></h3>
+            <p tabIndex="0">
                 It’s increasingly important to make time for self-improvement and career development, but it’s hard to know where to focus your efforts. As developers we’re often attracted to learning new technologies and languages, however I’d like to make the case for a number of non-technical areas of development that I believe can give you a huge advantage in your career.
             </p>
-            <p>
+            <p tabIndex="0">
                 In this talk, I’ll share a number of skills that I’ve found compliment a technical toolbelt, such as generating and maintaining momentum within your team and looking beyond requirements to identify opportunities for your business. I’ll also share some tips to help fast track your progress, exploring why it’s important to seek out and identify the gaps in your skill set, and how to seize opportunities to strengthen these areas.
             </p>
-            <p>
+            <p tabIndex="0">
                 It’s my hope that this talk will give you a different perspective of what makes a great developer, as well as the tools and motivation to broaden your expertise so that you can make a bigger impact in your organisation.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Mark_Towndrow.png" alt="Mark Towndrow" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Head of Engineering at OpenWrks</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Head of Engineering at OpenWrks</i></p>
+                    <p tabIndex="0">
                         Gained a Software Engineering degree at Nottingham Trent University, worked at TDX Group then Equifax before moving to Bizfitech / OpenWrks. Enjoy coding primarily in .NET (Core) and React but love playing with new technologies                   
                     </p>
                 </div>
@@ -213,7 +213,7 @@ export default () => (
         </section> 
                 
         <section name="galiya-warrier">
-            <h2>Galiya Warrier
+            <h2 tabIndex="0">Galiya Warrier
                 <Link target="_blank" href="https://twitter.com/galiyawarrier" onSelect={event => {
                     logEvent("twitter", "galiya-warrier")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -223,18 +223,18 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Deep Learning in the world of little ponies</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Deep Learning in the world of little ponies</i></h3>
+            <p tabIndex="0">
                 In this talk, we will discuss computer vision, one of the most common real-world applications of machine learning. We will deep dive into various state-of-the-art concepts around building custom image classifiers - application of deep neural networks, specifically convolutional neural networks and transfer learning. We will demonstrate how those approaches could be used to create your own image classifier to recognise the characters of "My Little Pony" TV Series [or Pokemon, or Superheroes, or your custom images].
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Galiya_Warrier.png" alt="Galiya Warrier" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Cloud Solution Architect (AA and AI), Microsoft</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Cloud Solution Architect (AA and AI), Microsoft</i></p>
+                    <p tabIndex="0">
                         I'm a Cloud Solution Architect at Microsoft, where I help enterprise customers adopt Advanced Analytics and Artifical Intelligence services on Microsoft Azure cloud.
                     </p>
                 </div>
@@ -242,31 +242,31 @@ export default () => (
         </section> 
                         
         <section name="robin-ninan">
-            <h2>Robin Ninan</h2>
+            <h2 tabIndex="0">Robin Ninan</h2>
             <h3>Talk: <i>Ditching the test pyramid in a microservices era</i></h3>
-            <p>
+            <p tabIndex="0">
                 We have all heard tales of the infamous test pyramid. Some of us have scaled the pyramid, some camped halfway and some dare not even attempt. Time and time again, I've heard of the test pyramid in multiple talks, test articles and blog posts, but not many have dared stray away from it. Why do we often return to the same solution for every test problem? 
             </p>
-            <p>
+            <p tabIndex="0">
                 What if we had another way forward; one that did not involve a pyramid. I once too advocated for the test pyramid in the good old times of monoliths. Times have changed.
             </p>
-            <p>
+            <p tabIndex="0">
                 We are now in the era of microservices and like many others, I found myself on shaky grounds with the test pyramid. It baffles me how little effort has been made to redefine or re-evaluate our quality assurance strategies. Whilst advances and breakthroughs are ripe in software development, our quality assurance processes and strategies often trail behind. 
             </p>
-            <p>
+            <p tabIndex="0">
                 So why had I found myself on shaky grounds with a test strategy that stood the test of time for so long? In this session, we unravel why the onset of microservices shook the pyramid and we explore how we could succeed without having to scale the pyramid.
             </p>
-            <p>
+            <p tabIndex="0">
                 If you, like me started off with the search for a better test strategy that has been tried and tested in the microservices furnace and ended up unsatisfied with the answers; let me introduce you to a new era.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Robin_Ninan.png" alt="Robin Ninan" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Senior QA @ Koodoo.io</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Senior QA @ Koodoo.io</i></p>
+                    <p tabIndex="0">
                         Senior QA at Koodoo. Seasoned Quality Assurance Engineer with an eye for test tools, strategies and architecture.
                     </p>
                 </div>
@@ -274,33 +274,33 @@ export default () => (
         </section> 
         
         <section name="ian-johnson">
-            <h2>Ian Johnson
+            <h2 tabIndex="0">Ian Johnson
                 <Link target="_blank" href="https://twitter.com/ijohnson_tnf" onSelect={event => {
                     logEvent("twitter", "ianjohnson")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Reasonable Code</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Reasonable Code</i></h3>
+            <p tabIndex="0">
                 In a reasonable a system (i.e. a system that helps me to understand it, to reason about it) I should be able to understand how to make a change without holding the entire system in my head. I should be able to reason where the change needs to be made and reason about the impact it will have.
             </p>
-            <p>
+            <p tabIndex="0">
                 I want to explore what reasonable means to me, from the processes of the team all the way down to an individual block of code. Along the way, we will encounter existing frameworks, tools, and patterns that our community has developed over the years to help us to reason about our code and processes; I feel that they have often been misused and end up creating the opposite effect, adding unnecessary complexity to how we work.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Ian_Johnson.png" alt="Ian Johnson" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Software developer, sketch noter</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Software developer, sketch noter</i></p>
+                    <p tabIndex="0">
                         Ian is a software developer working at Redgate, a company that develops tools for developers and database administrators.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         Ian is passionate about writing maintainable code that delivers on the needs of users. Though he considers himself an introvert, Ian loves talking with other developers, learning from their experiences and sharing his own.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         Outside of work, Ian is a passionate Star Wars fan and has been known to make the occasional really bad pun, but all of his code is "no-pun sourced" (sorry, couldn't resist).
                     </p>
                     <ul>
@@ -315,30 +315,30 @@ export default () => (
         </section> 
 
         <section name="samathy-barratt">
-            <h2>Samathy Barratt
+            <h2 tabIndex="0">Samathy Barratt
                 <Link target="_blank" href="https://twitter.com/samathy_barratt" onSelect={event => {
                     logEvent("twitter", "samathybarratt")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>This is a talk about Nothing.</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>This is a talk about Nothing.</i></h3>
+            <p tabIndex="0">
                 NULL, None, 0, nullptr, nil, NaN. Every programming language represents the concept of nothing, zero or just 'not a thing' in a different way.
             </p>
-            <p>
+            <p tabIndex="0">
                 This talk looks at the various different representations of 'nothing' in programming languages, exploring how the concept has developed over time, how representations differ and what each method has over another one.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Samathy_Barratt.png" alt="Samathy Barratt" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Magical Code Fairy</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Magical Code Fairy</i></p>
+                    <p tabIndex="0">
                         Samathy is an inquisitive code fairy who strives to understand complex computer science problems and loves to help others do the same. 
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         A Python programmer by day, and a passionate D programmer by night, she likes good challenges, good code and good coffee.
                     </p>
 
@@ -347,7 +347,7 @@ export default () => (
         </section> 
 
         <section name="ian-cooper">
-            <h2>Ian Cooper
+            <h2 tabIndex="0">Ian Cooper
                 <Link target="_blank" href="https://twitter.com/icooper" onSelect={event => {
                     logEvent("twitter", "iancooper")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -357,30 +357,30 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>How to Escape The Distributed Monolith</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>How to Escape The Distributed Monolith</i></h3>
+            <p tabIndex="0">
                 Microservices were all the rage, so you broke up your monolith. The services talk to each other by gRPC, you use a service mesh to route and load balance, and provide reliability oriented computing, you are fully buzzword compliant.
             </p>
-            <p>
+            <p tabIndex="0">
                 Yet something seems to be wrong.
             </p>
-            <p>
+            <p tabIndex="0">
                 You can't easily release software from one team, without coordinating with teams creating other. Testing has to be end-to-end to flush out problems or risk your team creating breaking changes for another team. Your 'heavy-lifters', whether you call the principals or architects seem to spend all their time on Docker, K8s, Istio and a whole slew of infrastructure technologies. Your system won't run without them, and you feel locked in.
             </p>
-            <p>
+            <p tabIndex="0">
                 What happened?
             </p>
-            <p>
+            <p tabIndex="0">
                 In this talk we look at the emerging world of "smart proxies and dumb endpoints" and ask whatever happened to the vision of "smart endpoints and dumb pipes", and what you can do to change course and deliver on the original promises of microservices to allow your teams to release frequently and independently of each other. And become masters of your tech stack, not its servants.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Ian_Cooper.png" alt="Ian Cooper" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Coding architect, pierced, bearded, tattooed</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Coding architect, pierced, bearded, tattooed</i></p>
+                    <p tabIndex="0">
                         Polyglot Coding Architect in London, founder of #ldnug, speaker, tabletop gamer, geek. Tattooed, pierced, and bearded. The 'guv' on @BrighterCommand
                     </p>
                 </div>
@@ -388,7 +388,7 @@ export default () => (
         </section> 
 
         <section name="helen-joy">
-            <h2>Helen Joy
+            <h2 tabIndex="0">Helen Joy
                 <Link target="_blank" href="https://twitter.com/LittleHelli" onSelect={event => {
                     logEvent("twitter", "helenjoy")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -398,24 +398,24 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Whose Design is it Anyway? - In introduction to inclusive design and research</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Whose Design is it Anyway? - In introduction to inclusive design and research</i></h3>
+            <p tabIndex="0">
                 As creators of products and services, we’re pretty good at thinking we’ve got it all sussed. We map user journeys, we create roadmaps, we write user stories. We know what we want people to do; what actions we want them to take. But do we really know who these people are? Do we really know what they need? Do we take the time to find out, or are we building products and services based on our own assumptions and biases?
             </p>
-            <p>
+            <p tabIndex="0">
                 And what about those who lack our digital privilege? Digital exclusion is a reality for many people. It’s our responsibility to look out for everyone, not just those who are the most visible or the easiest to design for.
             </p>
-            <p>
+            <p tabIndex="0">
                 As technologists, we have the power to massively hinder or improve lives; not those of ‘users’ but of people. This talk looks at what it means to be digitally excluded and how by adopting a practical user research-led attitude to design, we can create products that are not just appealing to us, but life-changing to those who use them.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Helen_Joy.png" alt="Helen Joy" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>UX Consultant at SPARCK</i></p>
-                    <p>
+                    <p tabIndex="0"><i>UX Consultant at SPARCK</i></p>
+                    <p tabIndex="0">
                         Helen Joy is a UX consultant and user researcher at SPARCK with a focus on universal and inclusive design practices. She's an organiser of Women in Tech Nottingham, working to promote inclusivity within the tech industry and raise the profile of talented female and gender minority speakers. When not consulting or speaking at events, Helen is an avid coffee drinker and hot yoga fan.
                     </p>
                 </div>
@@ -423,7 +423,7 @@ export default () => (
         </section> 
 
         <section name="joel-hammond-turner">
-            <h2>Joel Hammond-Turner
+            <h2 tabIndex="0">Joel Hammond-Turner
                 <Link target="_blank" href="https://twitter.com/Rammesses" onSelect={event => {
                     logEvent("twitter", "joelhammondturner")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -433,21 +433,21 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>You're the Tech Lead - *you* fix it!</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>You're the Tech Lead - *you* fix it!</i></h3>
+            <p tabIndex="0">
                 Over the last couple of years, I've presented 20 tricks and tips that I've found invaluable as a Tech Lead. But in this session, I want to turn things around and look at applying some of those to solving specific issues that are common within many software development teams.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Joel_Hammond-Turner.png" alt="Joel Hammond-Turner" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Tech Lead, Landmark Information Group</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Tech Lead, Landmark Information Group</i></p>
+                    <p tabIndex="0">
                         I've a very broad experience of software development over 15 years and a passion for both technology and elegance in my solutions that make me an extremely capable software architect.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         Personable and professional, I revel in complex challenges, but always make time to coach and mentor team members.
                     </p>
                 </div>
@@ -455,7 +455,7 @@ export default () => (
         </section> 
 
         <section name="zac-braddy">
-            <h2>Zac Braddy
+            <h2 tabIndex="0">Zac Braddy
                 <Link target="_blank" href="https://twitter.com/ZackerTheHacker" onSelect={event => {
                     logEvent("twitter", "zacbraddy")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -465,33 +465,33 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>All the mistakes I've made trying to implement Microservices</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>All the mistakes I've made trying to implement Microservices</i></h3>
+            <p tabIndex="0">
                 We're now entering the next age of Microservices. For about a decade now we've been doing battle with the pointy haired bosses of the world to convince them of what seems so painfully obvious to us; that there are many varied virtues of microservices architecture. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Now that they all have Netflix accounts and they've seen the benefits first hand we now seem to have those same bosses bursting into the office waving their trade magazine and asking us if we've heard about this "micro-system" thing. Flustered, we're having coming to terms now with how we actually deliver on our lofty promises without Amazon's finances and resources. 
             </p>
-            <p>
+            <p tabIndex="0">
                 Some people have been getting it right the first time they've tried which is great! Other people, like me, have got it right as well.....but....not before getting it wrong repeatedly for oh so many different reasons! So, I guess that makes me an expert, right?! 
             </p>
-            <p>
+            <p tabIndex="0">
                 Come listen as I shamefully regale you with all ways in which I've ham-fisted the most elegant architecture currently known to humanity in hopes that I might save you from the same sleepless nights.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Zac_Braddy.png" alt="Zac Braddy" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Lead Developer @Koodoo.io</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Lead Developer @Koodoo.io</i></p>
+                    <p tabIndex="0">
                         Zac is a Lead Fullstack Javascript developer at Koodoo.io where he helps to try and save people money on their mortgages. This makes him feel super good about how he spends his days.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         Zac has been developing for a number of years, 5 or 6 I think, I don't know who is counting? In that time has seen a very diverse set of tech and industries. Up until his current role he was working with the .NET stack so even languages are sacred to him. For Zac it's all about the next challenge and in the past that thirst for knowledge has seen him working with everything from hulking 20 year old Classic ASP monoliths to greenfield node microservices on bleed edge architecture and good amount of stuff in between.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         On the side Zac is active in the developer community writing blog posts, doing talks and mentoring other developers through their journeys in meet ups and online. When he isn't in front of his computer at work he is out geocaching with his sons and wife, playing D and D with friends or......let's face it probably on the computer still coding or gaming.
                     </p>
                 </div>
@@ -499,36 +499,36 @@ export default () => (
         </section> 
 
         <section name="neil-oconnor">
-            <h2>Neil O'Connor
+            <h2 tabIndex="0">Neil O'Connor
                 <Link target="_blank" href="https://twitter.com/1stmanonthesun" onSelect={event => {
                     logEvent("speakers", "neiloconnor")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>CTO secrets: How to get the best companies fighting to hire you</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>CTO secrets: How to get the best companies fighting to hire you</i></h3>
+            <p tabIndex="0">
                 As a CTO, I spend a lot of my time hiring talent and building high performance development teams. I have hired hundreds of software professionals over the years, and I still insist on interviewing every candidate personally. I think I’ve got a pretty good hit rate: my teams have all had great reputations in their local tech community, and I would rehire - in a heartbeat - almost everyone I’ve hired in the past.
             </p>
-            <p>
+            <p tabIndex="0">
                 It’s never been a better time to be working in the software industry. Your skills are in demand, but that doesn’t mean that everyone gets to work on the coolest tech in the most forward thinking companies. How do you set yourself apart from the crowd and get those companies falling over themselves to hire you?
             </p>
-            <p>
+            <p tabIndex="0">
                 In this session, I’ll share some of my secrets about what I look for in candidates. What is it that makes a candidate stand out? What do I look for in their CV? What is it about how they approach the interview or the technical assessment that impresses me? How important is formal education? What do I look for in how the candidate spends their spare time?
             </p>
-            <p>
+            <p tabIndex="0">
                 One myth to clear up right here: not everyone has to be a “rockstar developer”. I look for a balanced mix of skills in every candidate, and I’m often much more impressed by the quiet one who has demonstrated great judgment, insight or a capacity to learn. To continue the rockstar analogy, I’d much rather hire the reliable drummer or the skilful backing singer over the egotistical and unpredictable frontman!
             </p>
-            <p>
+            <p tabIndex="0">
                 This session will offer clear, practical advice on how you can maximise your personal value in the industry. Some of it will be quick and easy to achieve, while some of it will require you to make longer term changes to your mindset. But whether you are an old hand eyeing your next career move, or you are looking for your first job in the industry, there will be something in this talk for you.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                     <div className="columnleft">
                         <img src="/static/speakers/Neil_OConnor.png" alt="Neil O'Connor" className="speakerpic"/>
                     </div>
                     <div className="columnright">
-                        <p><i>CTO at Koodoo, a Nottingham-based fintech in the Blenheim Chalcot group</i></p>
-                        <p>
+                        <p tabIndex="0"><i>CTO at Koodoo, a Nottingham-based fintech in the Blenheim Chalcot group</i></p>
+                        <p tabIndex="0">
                             Neil has been building forward-thinking development teams since 1862. He was founding CTO at local companies Koodoo and Oakbrook Finance, and has worked in a wide array of techie roles in numerous industries. He believes that if something is worth doing, it's worth doing right, and aims to create environments where development teams can excel at what they do best.
                         </p>
                     </div>
@@ -536,7 +536,7 @@ export default () => (
         </section> 
 
         <section name="simon-painter">
-            <h2>Simon Painter
+            <h2 tabIndex="0">Simon Painter
                 <Link target="_blank" href="https://twitter.com/madSimonJ" onSelect={event => {
                     logEvent("twitter", "simonpainter")}}>
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "twitter"]} /></a>
@@ -546,39 +546,41 @@ export default () => (
                         <a target="_blank"><FontAwesomeIcon icon={["fab", "linkedin"]} /></a>
                 </Link>
             </h2>
-            <h3>Talk: <i>Hacking C#: Development for the Truly Lazy</i></h3>
-            <p>
+            <h3 tabIndex="0">Talk: <i>Hacking C#: Development for the Truly Lazy</i></h3>
+            <p tabIndex="0">
                 I don't know about you, but I'm a lazy developer. What do I mean by lazy? I don't mean I don't want to do my work - far from it - I mean that I hate to write out a great deal of code to get the job done. I want to accomplish my goals with as little effort as possible.
             </p>
-            <p>
+            <p tabIndex="0">
                 One of my pet hates is writing enhancements that involve copying and pasting blocks of code, changing a variable name, then leaving everything else the same. I hate having to consider each and every possible null reference exception, and adding in a whole ton of boilerplate to handle it. I hate having to spent ages jumping back and forth in a legacy codebase, trying to understand what it actually does!
             </p>
-            <p>
+            <p tabIndex="0">
                 What's the alternative? In this talk, I'll demonstrate a way of working that avoids all this unneccesary work, and gives you more time to do something more productive.
             </p>
-            <p>
+            <p tabIndex="0">
                 We'll look at:
             </p>
-                <li> - Functional Programming - what benefits does this increasingly popular paradigm bring us to cut down coding effort</li>
-                <li>- Linq and Generics - These have been a part of C# for a long time now, and are some of the most powerful features available in the language, but hardly anyone seems to be using them effectively</li>
-                <li>- MetaProgramming - break open C# and take it to the next level with code that describes how to generate code</li>
-            <p>
+                <ol>
+                    <li tabIndex="0"> - Functional Programming - what benefits does this increasingly popular paradigm bring us to cut down coding effort</li>
+                    <li tabIndex="0">- Linq and Generics - These have been a part of C# for a long time now, and are some of the most powerful features available in the language, but hardly anyone seems to be using them effectively</li>
+                    <li tabIndex="0">- MetaProgramming - break open C# and take it to the next level with code that describes how to generate code</li>
+                </ol>
+            <p tabIndex="0">
                 Our goal is to write code in as few lines as possible that provides the greatest amount of impact. We also want code that's readable, and easily maintainable. We want to think smart, and think...Lazy.
             </p>
-            <h3>Bio</h3>
+            <h3 tabIndex="0">Bio</h3>
             <div className="row">
                 <div className="columnleft">
                     <img src="/static/speakers/Simon_Painter.png" alt="Simon Painter" className="speakerpic"/>
                 </div>
                 <div className="columnright">
-                    <p><i>Senior Software Developer at EuroFins Scientific</i></p>
-                    <p>
+                    <p tabIndex="0"><i>Senior Software Developer at EuroFins Scientific</i></p>
+                    <p tabIndex="0">
                         I've been working as a .NET developer for over 12 years now in a variety of industries including government, retail and manufacturing. But as a coder, I've been playing with making computers do whatever my crazed imagination could devise since I was old enough to read my Dad's copy of the ZX Spectrum BASIC coders manual. 
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         I've been speaking about Functional C# at various user groups and conferences around the UK, USA, and India, and am particularly interested in seeing just how far we can push the capabilities of C#.
                     </p>
-                    <p>
+                    <p tabIndex="0">
                         When I'm not coding, or running after my two small children, I have been known to enjoy the classic series of Doctor Who, Fighting Fantasy Gamebooks, Cryptic Crosswords, and rather more coffee than is probably good for me.
                     </p>
                 </div>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I added tab indexes throughout the website so that users can navigate with the use of the `tab` and `shift-tab` buttons. In addition to the navigation and links having focus, I also added focus to the paragraphs and list items so that someone with a screen reader will be able to hear the information. Some HTML tags were also edited to be picked up better by a screen reader. For example, a subheader with just a `<strong>` tag was changed to use `<h4>` instead.

### Benefits

With the tab indexes added, users who rely on a11y should now be able to click on all links and be able to hear all pertinent information on a screenreader. 

### Applicable Issues

I broke down the tab indexes to focus on every paragraph and list item as mentioned above, but perhaps you might not want this many tab indexes? Also, although I did not add it since it was not asked in the requirements, but it is often a good idea to include a button to `skip to main content` that is only visible to a screen reader and is focusable. This way, a user does not have to always tab through the nav bar at the top every time they load a page on your site to get to the page's content. 