### PR TITLE
Improve image alt text for a11y

### DIFF
--- a/components/companies/Company.js
+++ b/components/companies/Company.js
@@ -4,7 +4,7 @@ import ExternalLink from '../ExternalLink'
 const Company = (props) => (
     <div>
          <ExternalLink href={props.partner.link} target="_blank" category="logo" eventType={props.partner.name}>
-            <img src={props.image}/>
+            <img src={props.image} alt={`Click to go to the ${props.partner.name} site`}/>
          </ExternalLink>
          
         <style jsx>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2851,7 +2851,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3216,7 +3217,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3264,6 +3266,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3302,11 +3305,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/pages/speakers.js
+++ b/pages/speakers.js
@@ -31,7 +31,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Dylan_Beattie.png" alt="Smiley face" className="speakerpic"/>
+                    <img src="/static/speakers/Dylan_Beattie.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Software Architect</i></p>
@@ -58,7 +58,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Matt_Brunt.png" alt="Smiley face" className="speakerpic"/>
+                    <img src="/static/speakers/Matt_Brunt.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Wizard</i></p>
@@ -96,7 +96,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Jessica_Salisbury.png" alt="Jessica Salisbury" className="speakerpic"/>
+                    <img src="/static/speakers/Jessica_Salisbury.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Behavioural Psychologist and Money Coaching Project Manager at Tully.</i></p>
@@ -131,7 +131,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Anthony_Dang.png" alt="Smiley face" className="speakerpic"/>
+                    <img src="/static/speakers/Anthony_Dang.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Head of Development</i></p>
@@ -169,7 +169,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Cara_Holland.png" alt="Cara Holland" className="speakerpic"/>
+                    <img src="/static/speakers/Cara_Holland.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Founder and head doodler at Graphic Change</i></p>
@@ -201,7 +201,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Mark_Towndrow.png" alt="Mark Towndrow" className="speakerpic"/>
+                    <img src="/static/speakers/Mark_Towndrow.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Head of Engineering at OpenWrks</i></p>
@@ -230,7 +230,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Galiya_Warrier.png" alt="Galiya Warrier" className="speakerpic"/>
+                    <img src="/static/speakers/Galiya_Warrier.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Cloud Solution Architect (AA and AI), Microsoft</i></p>
@@ -262,7 +262,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Robin_Ninan.png" alt="Robin Ninan" className="speakerpic"/>
+                    <img src="/static/speakers/Robin_Ninan.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Senior QA @ Koodoo.io</i></p>
@@ -290,7 +290,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Ian_Johnson.png" alt="Ian Johnson" className="speakerpic"/>
+                    <img src="/static/speakers/Ian_Johnson.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Software developer, sketch noter</i></p>
@@ -331,7 +331,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Samathy_Barratt.png" alt="Samathy Barratt" className="speakerpic"/>
+                    <img src="/static/speakers/Samathy_Barratt.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Magical Code Fairy</i></p>
@@ -376,7 +376,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Ian_Cooper.png" alt="Ian Cooper" className="speakerpic"/>
+                    <img src="/static/speakers/Ian_Cooper.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Coding architect, pierced, bearded, tattooed</i></p>
@@ -411,7 +411,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Helen_Joy.png" alt="Helen Joy" className="speakerpic"/>
+                    <img src="/static/speakers/Helen_Joy.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>UX Consultant at SPARCK</i></p>
@@ -440,7 +440,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Joel_Hammond-Turner.png" alt="Joel Hammond-Turner" className="speakerpic"/>
+                    <img src="/static/speakers/Joel_Hammond-Turner.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Tech Lead, Landmark Information Group</i></p>
@@ -481,7 +481,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Zac_Braddy.png" alt="Zac Braddy" className="speakerpic"/>
+                    <img src="/static/speakers/Zac_Braddy.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Lead Developer @Koodoo.io</i></p>
@@ -524,7 +524,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                     <div className="columnleft">
-                        <img src="/static/speakers/Neil_OConnor.png" alt="Neil O'Connor" className="speakerpic"/>
+                        <img src="/static/speakers/Neil_OConnor.png" alt="" className="speakerpic"/>
                     </div>
                     <div className="columnright">
                         <p><i>CTO at Koodoo, a Nottingham-based fintech in the Blenheim Chalcot group</i></p>
@@ -568,7 +568,7 @@ export default () => (
             <h3>Bio</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="/static/speakers/Simon_Painter.png" alt="Simon Painter" className="speakerpic"/>
+                    <img src="/static/speakers/Simon_Painter.png" alt="" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p><i>Senior Software Developer at EuroFins Scientific</i></p>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

- Removed the alt text for the speaker images as these images are decorative only. 
- Added descriptive alt text for the company logos. 

### Benefits

Improves the experience for users who rely on screen readers. 
Improves the Lighthouse Accessibility audit score (80 to 95)
![image](https://user-images.githubusercontent.com/22634756/66328004-b74e4d00-e923-11e9-844c-87e0e2d510a2.png)


### Applicable Issues

#97 