### PR TITLE
Fix hacktoberfest logo link.

### DIFF
--- a/pages/hacktoberfest.js
+++ b/pages/hacktoberfest.js
@@ -26,7 +26,7 @@ export default () => (
             <h3 tabIndex="0">About Hacktoberfest</h3>
             <div className="row">
                 <div className="columnleft">
-                    <img src="static/hacktoberfest.svg" alt="Hacktoberfest 2019 Logo" className="speakerpic"/>
+                    <img src="/static/hacktoberfest.svg" alt="Hacktoberfest 2019 Logo" className="speakerpic"/>
                 </div>
                 <div className="columnright">
                     <p tabIndex="0"><i>Hacktoberfest</i></p>


### PR DESCRIPTION
### Description of the Change

Fixes link to hacktoberfest logo svg file in static folder, as the link is currently showing as broken.

### Benefits

The image will no longer show as a broken link.

### Applicable Issues

N/A