### PR TITLE
Fix for nextjs 9 new export path output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@ const withCSS = require('@zeit/next-css');
 const glob = require('glob');
 
 module.exports = withCSS({
+  exportTrailingSlash: true,
   exportPathMap: async function(
     defaultPathMap,
     { dev, dir, outDir, distDir, buildId },


### PR DESCRIPTION
Previously sites would export under folders with an index.html. This has since changed. This change reverts this.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In version 9 of Nextjs, export outputs to file.html instead of /file/index.html. This change fixes this with a config setting that reverts it to the old behaviour.

### Benefits

Makes the site work

### Applicable Issues

None