### PR TITLE
Fix: Steve's picture link

### DIFF
--- a/pages/2021/speakers/speakergrid.js
+++ b/pages/2021/speakers/speakergrid.js
@@ -56,7 +56,7 @@ export default function Speaker2021Component() {
         />
         <SpeakerGridItemComponent
           speakername="Steve Collins"
-          pic="/static/speakers/2021/steve_collins.jpg"
+          pic="/static/speakers/2021/Steve_Collins.jpg"
           link="../steve-collins"
           talkbrief="The [Source Code] Generation Game"
         />


### PR DESCRIPTION
### Requirements

- Fix the picture of Steve on the speakers page

### Description of the Change

Change the casing on the image name

### Before

![image](https://user-images.githubusercontent.com/13496774/135447256-af862e33-3d0d-43b8-9e0e-71c5a132423e.png)

### After

![image](https://user-images.githubusercontent.com/13496774/135447225-d7ad65cf-962f-4c8d-9233-13df220b27ad.png)

### Benefits

N/A

### Applicable Issues

N/A