### PR TITLE
Pass secrets correctly to publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,7 @@ jobs:
     name: Publish to S3
     needs: ['test_build']
     uses: ./.github/workflows/publish_to_s3_job.yml
+    secrets:
+      aws_access_key_actions: ${{ secrets.AWS_ACCESS_KEY }}
+      aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_KEY }}
+      aws_distribution_id_actions: ${{ secrets.DISTRIBUTION_ID}}

--- a/.github/workflows/publish_to_s3_job.yml
+++ b/.github/workflows/publish_to_s3_job.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    secrets:
+      aws_access_key_actions:
+        required: true
+      aws_secret_access_key_actions:
+        required: true
+      aws_distribution_id_actions:
+        required: true
 
 jobs:
   publish_to_s3:
@@ -21,8 +28,8 @@ jobs:
 
       - name: Configure AWS
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_actions }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key_actions }}
         run: |
           aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
           aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
@@ -31,16 +38,16 @@ jobs:
 
       - name: Deploy To S3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_actions }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key_actions }}
         run: |
           aws s3 sync ./out s3://www.dddeastmidlands.com --delete
 
       - name: Invalidate Cache
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          DISTRIBUTION_ID: ${{ secrets.DISTRIBUTION_ID}}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_actions }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key_actions }}
+          DISTRIBUTION_ID: ${{ secrets.aws_distribution_id_actions}}
         run: |
           aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/*"
 


### PR DESCRIPTION
### Description of the Change
Fixes an issue where the new github actions job for publishing the site does not pass the secrets to the job correctly.

### Benefits

Path to live works
