### PR TITLE
Enable dependabot to trigger after tests pass

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -17,5 +17,5 @@ jobs:
 
   dependabot:
     name: Dependabot Approve and Auto Merge
-    needs: ['publish_unit_tests']
+    needs: ['test_build']
     uses: ./.github/workflows/dependabot-approve-and-auto-merge_job.yml


### PR DESCRIPTION
### Description of the Change

Now all workflows are tested and passing, actually enable dependabot to run after tests pass.

Initially will still require a manual approval until we are confident to let it auto merge completely in the future.

