### PR TITLE
Enhancement: Add link to sponsorship tiers to the sponsorship page

### DIFF
--- a/pages/2023/sponsor.js
+++ b/pages/2023/sponsor.js
@@ -71,6 +71,14 @@ export default function Sponsor() {
         <section className="content-section" id="sponsor-info">
           <h1 tabIndex="0">Want More Information?</h1>
           <p tabIndex="0">
+            For more information on the sponsorship tiers available,
+            head to the{' '}
+            <a href="/2023/sponsorship-tiers" rel="noreferrer">
+              {' '}
+              sponsorship tier page
+            </a>
+          </p>
+          <p tabIndex="0">
             Here are some pages with more information relating to
             sponsoring the event.
           </p>


### PR DESCRIPTION
### Requirements
The [sponsor page](https://www.dddeastmidlands.com/2023/sponsor/) has a link to the [sponsorship tier page](https://www.dddeastmidlands.com/2023/sponsorship-tiers/)

### Description of the Change
Add link to sponsor the event page to the sponsorship tier page. 

### Screenshots

![image](https://user-images.githubusercontent.com/13496774/196189414-20d62fbb-b9ba-41ce-8125-9f8fad660b59.png)


### Benefits

N/A

### Applicable Issues

N/A