### PR TITLE
Enhancement: Remove Apply to Speak Links

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -16,7 +16,7 @@ export default function Navigation() {
             <Nav.Item>
               <Nav.Link href="/">Home</Nav.Link>
             </Nav.Item>
-            
+
             <NavDropdown
               tabIndex="0"
               title="Information"

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -16,21 +16,7 @@ export default function Navigation() {
             <Nav.Item>
               <Nav.Link href="/">Home</Nav.Link>
             </Nav.Item>
-
-            <Nav.Item>
-              <Nav.Link
-                tabIndex="0"
-                rel="noopener noreferrer"
-                target="_blank"
-                href="https://sessionize.com/ddd-east-midlands-conference-2023/"
-                onSelect={() => {
-                  logEvent('navigation', 'sessionize');
-                }}
-              >
-                Apply To Speak
-              </Nav.Link>
-            </Nav.Item>
-
+            
             <NavDropdown
               tabIndex="0"
               title="Information"

--- a/data/dates.js
+++ b/data/dates.js
@@ -12,7 +12,7 @@ const dates = [
   },
   {
     id: 3,
-    date: '14th April 2023',
+    date: '17th April 2023',
     name: 'First Wave Of Tickets Released',
   },
   {
@@ -22,7 +22,7 @@ const dates = [
   },
   {
     id: 5,
-    date: '1st May 2023',
+    date: '19th May 2023',
     name: 'Voting Closes',
   },
   {

--- a/pages/index.js
+++ b/pages/index.js
@@ -35,22 +35,6 @@ export default function Index() {
       </section>
 
       <section className="content-section">
-        <div className="speak-button">
-          <div className="speak-button-container">
-            <div className="speak-button">
-              <a
-                href="https://sessionize.com/ddd-east-midlands-conference-2023/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Apply To Speak
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="content-section">
         <Image
           className="pageimage"
           src="/static/pageimage/happy.jpg"


### PR DESCRIPTION
### Requirements

As the application for talks has now ended, we can remove the links to sessionize for talk submissions.
Dates are also updated to match @geeksareforlife's schedule

### Screenshots

![image](https://user-images.githubusercontent.com/13496774/231216060-82f0588a-dc47-41e8-8c3b-30165042cd98.png)

### Benefits

Reduce noise from webstie

### Applicable Issues

N/A
